### PR TITLE
CCITCARBON-218

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ clean-all: clean-pyc clean-tests clean
 test-all: test-functional test-scenario
 
 test-functional:
-	tox -e py27-unit,py3-unit
+	tox -e py3-unit
 
 test-scenario:
-	tox -e py27-scenario,py3-scenario
+	tox -e py3-scenario
 
 clean:
 	rm -rf *.egg

--- a/teflo/executors/ext/ansible_executor_plugin/ansible_executor_plugin.py
+++ b/teflo/executors/ext/ansible_executor_plugin/ansible_executor_plugin.py
@@ -113,17 +113,17 @@ class AnsibleExecutorPlugin(ExecutorPlugin):
             elif validrc:
                 if result['rc'] not in validrc:
                     self.status = 1
-                    self.logger.error('Shell command %s failed. Host=%s rc=%d Error: %s'
+                    self.logger.error('Command %s failed. Host=%s rc=%d Error: %s'
                                       % (shell['command'], result['host'], result['rc'], result['err']))
 
             else:
                 if result['rc'] != 0:
                     self.status = 1
-                    self.logger.error('Shell command %s failed. Host=%s rc=%d Error: %s'
+                    self.logger.error('Command %s failed. Host=%s rc=%d Error: %s'
                                       % (shell['command'], result['host'], result['rc'], result['err']))
 
             if self.status == 1:
-                raise ArchiveArtifactsError('Script %s failed to run successfully!' % shell['name'])
+                raise ArchiveArtifactsError('Command %s failed to run ' % shell['name'])
             else:
                 self.logger.info('Successfully executed command : %s' % shell['command'])
 
@@ -156,8 +156,7 @@ class AnsibleExecutorPlugin(ExecutorPlugin):
                     self.logger.error('Script %s failed. Host=%s rc=%d Error: %s'
                                       % (script['name'], result['host'], result['rc'], result['err']))
             if self.status == 1:
-                raise ArchiveArtifactsError('Script %s failed to run '
-                                            'successfully!' % script['name'])
+                raise ArchiveArtifactsError('Script %s failed to run' % script['name'])
             else:
                 self.logger.info('Successfully executed script : %s' % script['name'])
 
@@ -176,7 +175,7 @@ class AnsibleExecutorPlugin(ExecutorPlugin):
                                  % playbook['name'])
             elif results[0] != 0:
                 self.status = 1
-                raise ArchiveArtifactsError('Playbook %s failed to run successfully!' % playbook['name'])
+                raise ArchiveArtifactsError('Playbook %s failed to run' % playbook['name'])
             else:
                 self.logger.info('Successfully executed playbook : %s' % playbook['name'])
 

--- a/teflo/orchestrators/ext/ansible_orchestrator_plugin/ansible_orchestrator_plugin.py
+++ b/teflo/orchestrators/ext/ansible_orchestrator_plugin/ansible_orchestrator_plugin.py
@@ -120,7 +120,7 @@ class AnsibleOrchestratorPlugin(OrchestratorPlugin):
         self.logger.info('Executing playbook:')
         results = self.ans_service.run_playbook(self.playbook)
         if results[0] != 0:
-            raise TefloOrchestratorError('Playbook %s failed to run successfully!' % self.playbook['name'])
+            raise TefloOrchestratorError('Playbook %s failed to run' % self.playbook['name'])
         else:
             self.logger.info('Successfully completed playbook : %s' % self.playbook['name'])
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # Refactored per https://blog.ionelmc.ro/2015/04/14/tox-tricks-and-patterns/#partial-environment-reuse
 [tox]
-envlist = py{27,3}-{unit,scenario},docs,docs-wiki
+envlist = py{3}-{unit,scenario},docs,docs-wiki
 
 [base]
 deps = -r{toxinidir}/test-requirements.txt
@@ -9,8 +9,7 @@ deps = -r{toxinidir}/test-requirements.txt
 sitepackages = true
 download = true
 envdir =
-    py27,docs,docs-wiki: {toxworkdir}/py27
-    py3: {toxworkdir}/py3
+    py3,docs,docs-wiki: {toxworkdir}/py3
 deps = {[base]deps}
 changedir=
     unit: tests/functional
@@ -22,8 +21,8 @@ setenv =
 whitelist_externals =
     teflo
 commands =
-    py{27,3}-unit: {[unittest]commands}
-    py{27,3}-scenario: {[scenariotest]commands}
+    py{3}-unit: {[unittest]commands}
+    py{3}-scenario: {[scenariotest]commands}
 
 [unittest]
 commands =


### PR DESCRIPTION
CCITCARBON-218 Alter error message to not contain the words fail and success simultaneously
* Updated the error messages for orchestrator and executor plugins
* Updated tox.ini and Makefile to remove py27 commands