### PR TITLE
CCITCARBON-237 point to the new plugin docs in GH pages

### DIFF
--- a/docs/users/definitions/notifications.rst
+++ b/docs/users/definitions/notifications.rst
@@ -352,4 +352,4 @@ Sending Chat Notifications
 Teflo_webhooks_notification_plugin allows users to send chat notification
 during and/or post teflo run. To get more information about this plugin ,on how to install and use it
 please visit `teflo_webhooks_notification_plugin
-<https://github.com/RedHatQE/teflo_webhooks_notification_plugin.git>`_
+<https://redhatqe.github.io/teflo_webhooks_notification_plugin/index.html>`_

--- a/docs/users/definitions/provision.rst
+++ b/docs/users/definitions/provision.rst
@@ -400,7 +400,7 @@ In your scenario descriptor file specify the **provisioner** key in your provisi
     provisioner: openstack-client
 
 For more information on how to install plugin and setup the scenario descriptor file for using this plugin,
-please refer `here <https://github.com/RedHatQE/teflo_openstack_client_plugin/blob/master/docs/user.md>`__
+please refer `here <here <https://redhatqe.github.io/teflo_openstack_client_plugin/docs/user.html>`__
 
 
 .. _linchpin_provisioning:
@@ -420,7 +420,7 @@ User can now install this plugin from Teflo
     $ pip install teflo[linchpin-wrapper]
 
 You can also refer to the
-`plugin <https://github.com/RedHatQE/teflo_linchpin_plugin/blob/master/docs/user.md>`__
+`plugin <https://redhatqe.github.io/teflo_linchpin_plugin/docs/user.html>`__
 documentation directly
 
 In your scenario file specify the **provisioner** key in your provision section.
@@ -431,7 +431,7 @@ In your scenario file specify the **provisioner** key in your provision section.
 
 
 Specify any of the
-`keys <https://github.com/RedHatQE/teflo_linchpin_plugin/blob/master/docs/user.md#provisioning-assets-with-linchpin>`__
+`keys <https://redhatqe.github.io/teflo_linchpin_plugin/docs/user.html#provisioning-assets-with-linchpin>`__
 supported by the linchpin provisioner.
 
 
@@ -467,14 +467,14 @@ following options
    credential environmental variables supported by Linchpin/Ansible yourself.
 
 For more information refer to the plugins
-`credential <https://github.com/RedHatQE/teflo_linchpin_plugin/blob/master/docs/user.md#credentials>`__
+`credential <https://redhatqe.github.io/teflo_linchpin_plugin/docs/user.html#credentials>`__
 document section.
 
 Examples
 ++++++++
 
 Below we will just touch on a couple examples. You can see the rest of the
-`examples <https://github.com/RedHatQE/teflo_linchpin_plugin/blob/master/docs/user.md#examples>`__
+`examples <https://redhatqe.github.io/teflo_linchpin_plugin/docs/user.html#examples>`__
 in the plugin documentation.
 
 Example 1
@@ -610,8 +610,8 @@ For those that want to use Linchpin to generate the inventory file. You must do 
 
  - Do NOT specify **groups** and **ansible_params** keys
 
-Refer to `example 6 <https://github.com/RedHatQE/teflo_linchpin_plugin/blob/master/docs/user.md#example-6>`__
-and `example 8 <https://github.com/RedHatQE/teflo_linchpin_plugin/blob/master/docs/user.md#example-8>`__
+Refer to `example 6 <https://redhatqe.github.io/teflo_linchpin_plugin/docs/user.html#example-6>`__
+and `example 8 <https://redhatqe.github.io/teflo_linchpin_plugin/docs/user.html#example-8>`__
 in the Linchpin plugin documents to see the two variations.
 
 Defining Static Machines

--- a/docs/users/install.rst
+++ b/docs/users/install.rst
@@ -81,7 +81,7 @@ Teflo_Linchpin_Plugin
 This plugin can be use to provision using the Linchpin tool.
 The Linchpin plugin will be available as an extra. To install Linchpin certain requirements need to be
 met so that it can be installed correctly. Please refer to the
-`before install section <https://github.com/RedHatQE/teflo_linchpin_plugin/blob/master/docs/user.md#before-install>`__
+`before install section <https://redhatqe.github.io/teflo_linchpin_plugin/docs/user.html#before-install>`__
 of the plugin documentation on how to install them.
 
 Once installed, you can install Linchpin from Teflo
@@ -92,14 +92,14 @@ Once installed, you can install Linchpin from Teflo
 
 Once Linchpin_Plugin is installed, you will get support for all providers that linchpin supports. Although there are
 some providers that require a few more dependencies to be installed. Refer to the
-`post-install section <https://github.com/RedHatQE/teflo_linchpin_plugin/blob/master/docs/user.md#post-install>`__
+`post-install section <https://redhatqe.github.io/teflo_linchpin_plugin/docs/user.html#post-install>`__
 of the plugin document for methods on how to install those dependencies.
 
 Openstack_Client_Plugin
 ~~~~~~~~~~~~~~~~~~~~~~~
 This plugin is used to Provision openstack assets using openstack-client tool
 This plugin is also available as extra. To install this  plugin do the following
-Refer `here <https://github.com/RedHatQE/teflo_openstack_client_plugin/blob/master/docs/user.md>`__ to get more
+Refer `here <https://redhatqe.github.io/teflo_openstack_client_plugin/docs/user.html>`__ to get more
 information on how to use the plugin
 
 .. code-block:: bash
@@ -147,7 +147,7 @@ Teflo_Webhooks_Notification_Plugin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This plugin is used to notify based users using chat applications gchat and slack.
-Please review the `repo documentation <https://github.com/RedHatQE/teflo_webhooks_notification_plugin/blob/master/docs/user.md>`__
+Please review the `repo documentation <https://redhatqe.github.io/teflo_webhooks_notification_plugin/user.html>`__
 and how to use the plugin.Please review `Teflo's notification triggers <./definitions/notifications.html#triggers>`__
 to get more info on using Teflo`s notification feature
 


### PR DESCRIPTION
We need to merge it only after the [PR](https://github.com/RedHatQE/teflo_webhooks_notification_plugin/pull/11) of teflo webhook notification plugin is merged and we can see GH pages is up and running.