### PR TITLE
CCITCARBON-275 Use pyssh over paramiko library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         'python-cachetclient',
         'ruamel.yaml>=0.15.64',
         'paramiko>=2.4.2',
+        'ssh-python==0.9.0',
         'requests>=2.20.1',
         'urllib3<1.26'
     ],

--- a/teflo/helpers.py
+++ b/teflo/helpers.py
@@ -30,7 +30,6 @@ import os
 import pkgutil
 import random
 import re
-import socket
 import string
 import subprocess
 import sys
@@ -56,6 +55,11 @@ from pykwalify.core import Core
 from pykwalify.errors import CoreError, SchemaError
 from xml.etree import cElementTree as ET
 from functools import reduce
+import socket
+from ssh.session import Session
+from ssh.key import import_privkey_file
+from ssh import options
+
 
 import pkg_resources
 
@@ -868,19 +872,23 @@ def ssh_retry(obj):
             attempt = 1
             while attempt <= MAX_ATTEMPTS:
                 try:
-                    ssh = SSHClient()
-                    ssh.set_missing_host_key_policy(WarningPolicy())
+                    pkey = import_privkey_file(server_key_file)
+                    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    sock.connect((server_ip, server_ssh_port))
+
+                    session = Session()
+                    session.options_set(options.USER, server_user)
+                    session.options_set(options.HOST, server_ip)
+                    session.options_set_port(server_ssh_port)
+                    session.options_set(options.TIMEOUT, 5)
 
                     # Test ssh connection
-                    ssh.connect(server_ip,
-                                port=server_ssh_port,
-                                username=server_user,
-                                key_filename=server_key_file,
-                                timeout=5)
+                    session.connect()
+                    rc = session.userauth_publickey(pkey)
                     LOG.debug("Server %s - IP: %s is reachable." %
                               (group, server_ip))
-                    ssh.close()
                     break
+
                 except (BadHostKeyException, AuthenticationException,
                         SSHException, socket.error) as ex:
                     attempt = attempt + 1


### PR DESCRIPTION
Using paramiko was causing issues while testing with RH9
RFE was to use pyssh instead of paramiko