### PR TITLE
CCITCARBON-290 Corrected PR for use of ssh-python over paramiko

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         'python-cachetclient',
         'ruamel.yaml>=0.15.64',
         'paramiko>=2.4.2',
+        'ssh-python==0.9.0',
         'requests>=2.20.1',
         'urllib3<1.26'
     ],


### PR DESCRIPTION
corrected syntax for timeout
added correct exceptions in try-catch block
successful run using my local branch
https://ci-ops-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/teflo-include-e2e-test-openstack-libcloud-3/122/console