### PR TITLE
Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# IDEs
+.idea
+.vscode
+
+# Sphix documentation
+docs/_build/
+
+# Unit tests / coverage
+coverage/
+*.coverage
+.tox/


### PR DESCRIPTION
This change adds a gitignore file to ignore certain files from being checked into source control. Teflos former project carbon originally had one.