### PR TITLE
Update teflos package classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
     zip_safe=False,
+    python_requires=">=3.6",
     install_requires=[
         'ansible>=2.5.0',
         'apache-libcloud==2.2.0',
@@ -69,12 +70,12 @@ setup(
 
                     },
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
-        'Natural Language :: English',
         'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.6',
     ],
     entry_points={


### PR DESCRIPTION
This change updates the classifiers to reflect teflos latest status:
 - Drops classifier for python 2 support as its no longer supported
 - Sets programming language to only python 3
 - Sets development status to stable over initial pre-alpha
 - Sets the minimal python version to 3.6 for installation

Updating the classifiers to reflect the latest status will make teflo more easily searchable on PyPI [1].

[1] https://pypi.org/project/teflo/