### PR TITLE
rfe: openstack instance metadata

### DIFF
--- a/docs/users/definitions/provision.rst
+++ b/docs/users/definitions/provision.rst
@@ -333,6 +333,7 @@ resource for OpenStack using the **openstack-libcloud** provisioner:
         networks: <networks>
         floating_ip_pool: <floating_ip_pool>
         keypair: <keypair>
+        server_metadata: <dict_key_values>
 
 .. list-table::
     :widths: auto
@@ -373,6 +374,11 @@ resource for OpenStack using the **openstack-libcloud** provisioner:
         - The name of the keypair to associate the node with.
         - String
         - True
+
+    *   - server_metadata
+        - Metadata to associate with the node.
+        - Dict
+        - False
 
 Example
 +++++++

--- a/examples/docs-usage/provision.yml
+++ b/examples/docs-usage/provision.yml
@@ -106,6 +106,9 @@ provision:
       - '{{ network }}'
     floating_ip_pool: "10.8.240.0"
     keypair: '{{ keypair }}'
+    server_metadata:
+      provisioned_by: "teflo"
+      build_url: "jenkins.com/build/123"
     ansible_params:
       ansible_user: cloud-user
       ansible_ssh_private_key_file: "keys/{{ keypair }}"

--- a/teflo/provisioners/ext/os_libcloud_plugin/openstack_libcloud_plugin.py
+++ b/teflo/provisioners/ext/os_libcloud_plugin/openstack_libcloud_plugin.py
@@ -356,7 +356,7 @@ class OpenstackLibCloudProvisionerPlugin(ProvisionerPlugin):
 
         raise OpenstackProviderError('Unable to get FIP for node!')
 
-    def create_node(self, name, image, size, network, key_pair):
+    def create_node(self, name, image, size, network, key_pair, metadata):
         """Create node.
 
         This method will create a new node in openstack. The node will be
@@ -374,6 +374,8 @@ class OpenstackLibCloudProvisionerPlugin(ProvisionerPlugin):
         :type network: str
         :param key_pair: Key pair to inject into node.
         :type key_pair: str
+        :param metadata: Metadata for the node.
+        :type metadata: Dict[str, str]
         :return: Node object.
         :rtype: object
         """
@@ -381,8 +383,8 @@ class OpenstackLibCloudProvisionerPlugin(ProvisionerPlugin):
 
         self.logger.debug('Creating node %s.' % name)
         self.logger.debug('Node details:\n * keypair=%s\n * image=%s\n '
-                          '* flavor=%s\n * networks=%s' %
-                          (key_pair, image, size, network))
+                          '* flavor=%s\n * networks=%s\n * metadata=%s' %
+                          (key_pair, image, size, network, metadata))
 
         # cache image object
         _image = self.image_lookup(image)
@@ -401,7 +403,8 @@ class OpenstackLibCloudProvisionerPlugin(ProvisionerPlugin):
                     image=_image,
                     size=_size,
                     networks=_network,
-                    ex_keyname=key_pair
+                    ex_keyname=key_pair,
+                    ex_metadata=metadata
                 )
                 self.logger.info('Successfully booted node %s.' % name)
                 return node
@@ -453,7 +456,7 @@ class OpenstackLibCloudProvisionerPlugin(ProvisionerPlugin):
             'Maximum attempts reached to delete node %s.' % node.name
         )
 
-    def _create(self, name, image, size, network, key_pair, fip):
+    def _create(self, name, image, size, network, key_pair, fip, metadata):
         """Create.
 
         This method will create a resource (node) in openstack. It will
@@ -474,6 +477,8 @@ class OpenstackLibCloudProvisionerPlugin(ProvisionerPlugin):
         :type key_pair: str
         :param fip: Floating ip pool.
         :type fip: str
+        :param metadata: Metadata for the node.
+        :type metadata: Dict[str, str]
         :return: Node fip. id.
         :rtype: str(s)
         """
@@ -481,7 +486,7 @@ class OpenstackLibCloudProvisionerPlugin(ProvisionerPlugin):
 
         # create node
         try:
-            node = self.create_node(name, image, size, network, key_pair)
+            node = self.create_node(name, image, size, network, key_pair, metadata)
         except Exception:
             self.logger.error("Failed to create node %s " % name)
             raise
@@ -674,7 +679,8 @@ class OpenstackLibCloudProvisionerPlugin(ProvisionerPlugin):
             self.provider_params.get('flavor'),
             self.provider_params.get('networks'),
             self.provider_params.get('keypair'),
-            self.provider_params.get('floating_ip_pool', None)
+            self.provider_params.get('floating_ip_pool', None),
+            self.provider_params.get('server_metadata', {})
         )
 
         return [dict(hostname=hostname, asset_id=_id, ip=_ip)]

--- a/teflo/provisioners/ext/os_libcloud_plugin/schema.yml
+++ b/teflo/provisioners/ext/os_libcloud_plugin/schema.yml
@@ -21,6 +21,14 @@ mapping:
   keypair:
     required: False
     type: str
+  server_metadata:
+    required: False
+    type: map
+    allowempty: True
+    mapping:
+      regex;(.*):
+        required: False
+        type: any
   credential:
     required: False
     type: map


### PR DESCRIPTION
add a new config block to the schema named `server_metadata` which allows for
key + values that will be associated with the created node. Named
`server_metadata` due to clashing with internal `metadata` field.

```
---
name: provision_base
description: >
  Provision task hosts 

provision:
  - name: "bpratt-metadata-test"
    groups:
      - "ocp_test_driver"
    provider:
      name: openstack
      credential: "openstack"
      image: "RHEL-8.3.0-x86_64-production-latest"
      flavor: "{{ OS_FLAVOR | default('ci.m1.small') }}"
      networks:
        - "provider_net_cci_8"
      keypair: "id_rsa"
      server_metadata:
        autumn: "MYAAA"
    ansible_params:
      ansible_user: cloud-user
      ansible_ssh_private_key_file: "keys/id_rsa"
```

![example](https://user-images.githubusercontent.com/29494941/124272533-7d17dc80-db04-11eb-8abc-405ca2bada6c.png)

Please let me know if there is any docs I can update to include this. I think https://github.com/RedHatQE/teflo_openstack_client_plugin/issues/9 should stay open since this is a different implementation.
