### PR TITLE
provisioners: support bkr's ks-append(s) option

### DIFF
--- a/docs/users/definitions/provision.rst
+++ b/docs/users/definitions/provision.rst
@@ -153,6 +153,7 @@ provisioning resource for Beaker using the **beaker-client** provisioner:
         ignore_panic: <True or False>
         taskparam: [<list of task parameter settings>]
         ksmeta: [<list of kick start meta OPTIONS>]
+        ksappends: [<list of kickstart append scripts>]
         metadata: <dict_key_values>
         ansible_params: <dict_key_values>
 
@@ -294,11 +295,16 @@ provisioning resource for Beaker using the **beaker-client** provisioner:
         - List
         - False
 
+    *   - ksappends
+        - partial kickstart scripts to append to the main kickstart file
+        - List
+        - False
+
 Example
 +++++++
 
 .. literalinclude:: ../../../examples/docs-usage/provision.yml
-    :lines: 68-90
+    :lines: 68-95
 
 .. _openstack_provisioning:
 
@@ -384,7 +390,7 @@ Example
 +++++++
 
 .. literalinclude:: ../../../examples/docs-usage/provision.yml
-    :lines: 94-111
+    :lines: 98-119
 
 Provisioning Openstack Assets using teflo_openstack_client_plugin
 ------------------------------------------------------------------
@@ -633,7 +639,7 @@ Example
 +++++++
 
 .. literalinclude:: ../../../examples/docs-usage/provision.yml
-    :lines: 114-124
+    :lines: 122-132
 
 There may also be a scenario where you want to run cmds or scripts on the
 local system instead of the provisioned resources.  Refer to the

--- a/examples/docs-usage/provision.yml
+++ b/examples/docs-usage/provision.yml
@@ -84,6 +84,11 @@ provision:
     password: '{{ password }}'
     host_requires_options:
       - "force={{ host_fqdn }}"
+    ksappends:
+      - |
+        %post
+        echo "This is my extra %post script"
+        %end
     ssh_key: "keys/{{ key_name }}"
     ansible_params:
       ansible_user: root

--- a/teflo/provisioners/ext/bkr_client_plugin/beaker_client_plugin.py
+++ b/teflo/provisioners/ext/bkr_client_plugin/beaker_client_plugin.py
@@ -577,6 +577,7 @@ class BeakerXML(object):
         self._kernel_options_post = ""
         self._kickstart = ""
         self._ksmeta = ""
+        self._ksappends = []
         self._remove_task = False
         self._virtmachine = False
         self._virtcapable = False
@@ -684,6 +685,11 @@ class BeakerXML(object):
         # Set kick start meta options
         if self.ksmeta != "":
             self.cmd += " --ks-meta '" + " ".join(self.ksmeta) + "'"
+
+        # Set kickstart append script
+        if self.ksappends != []:
+            for ksappend in self.ksappends:
+                self.cmd += " --ks-append '" + ksappend + "'"
 
         # Set debug and dryrun
         self.cmd += " --debug --dryrun"
@@ -861,6 +867,17 @@ class BeakerXML(object):
         """Set kick start meta data.
         :param meta: meta data"""
         self._ksmeta = meta
+
+    @property
+    def ksappends(self):
+        """Return the kick start append scripts."""
+        return self._ksappends
+
+    @ksappends.setter
+    def ksappends(self, scripts):
+        """Set kick start append scripts.
+        :param scripts: ksappend scripts"""
+        self._ksappends = scripts
 
     @property
     def arch(self):

--- a/teflo/provisioners/ext/bkr_client_plugin/schema.yml
+++ b/teflo/provisioners/ext/bkr_client_plugin/schema.yml
@@ -97,6 +97,11 @@ mapping:
     type: seq
     sequence:
       - type: str
+  ksappends:
+    required: False
+    type: seq
+    sequence:
+      - type: str
   job_url:
     required: False
     type: str


### PR DESCRIPTION
bkr client's `--ks-append` allows for specifiying additional kickstart
commands to add to the base kickstart file. Multiple `--ks-append`
options are respected by the client, therefore allow for multiple
`ksappend` blocks in the sdf.

https://beaker-project.org/docs/user-guide/customizing-installation.html#appended-kickstart-content
https://beaker-project.org/docs/man/bkr.html#cmdoption-bkr-ks-append

closes #97

example from cli:

```bash
bkr workflow-simple \
  --whiteboard="example" \
  --family="RedHatEnterpriseLinux8" \
  ...
  --ks-append="
%post
echo "This is my extra %post script"
%end
" \
  --task="/distribution/check-install" \
  --wait
```

example from sdf:

```yaml
---
name: beaker resource
description: define a teflo host beaker resource to be provisioned

provision:
  - name: test_driver
    groups:
      - driver
    provider:
      whiteboard: mock
      name: beaker
      arch: "{{ ARCH }}"
      variant: "{{ VARIANT }}"
      credential: "{{ BEAKER_CREDENTIAL }}"
      distro: "RHEL-8.3.0"
      jobgroup: "{{ BKR_GROUP }}"
      ssh_key: "keys/{{ OS_KEYPAIR }}"
      username: "{{ BKR_USERNAME }}"
      password: "{{ BKR_PASSWORD }}"
      ksappends:
        - |
          %post
          echo "This is my extra %post script"
          %end
      host_requires_options: ["memory>=4096", "cpu_count>=2"]
    ansible_params:
      ansible_user: root
      ansible_ssh_private_key_file: "keys/{{ OS_KEYPAIR }}"
```

resulting job xml ksappend block:

```xml
<ks_appends>
  <ks_append>%post echo "This is my extra %post script" %end </ks_append>
</ks_appends>
```

updated docs:
![2021-07-19_07-36](https://user-images.githubusercontent.com/29494941/126160740-1cd35193-d2fe-45cd-8a88-7cf6064b3e4d.png)

beaker ui:
![2021-07-19_06-45](https://user-images.githubusercontent.com/29494941/126160442-7690e9d5-a512-49af-a99f-5b315aed6147.png)

beaker program.log:
![2021-07-19_07-40](https://user-images.githubusercontent.com/29494941/126161222-c4321f46-9e93-4dd4-8abb-8883340f6437.png)
