### PR TITLE
Added fix for resource ordering issue in results.yml

### DIFF
--- a/teflo/resources/scenario.py
+++ b/teflo/resources/scenario.py
@@ -183,22 +183,202 @@ class Scenario(TefloResource):
             return all_notifications
         return getattr(self, 'notifications')
 
-    def add_resource(self, item):
+    def get_resource_idx(self, item):
+        """
+        Get the idx of the resource in its corresponding list.
+        :param item:
+        :return:
+        """
+        if isinstance(item, Asset):
+            try:
+                return self._assets.index(item)
+            except ValueError:
+                # Just in case attempt to locate the resource index by name
+                # since some tasks run in parallel and when they return
+                # the resource object it is a different memory reference.
+                # Since the resource objects don't have an implementation
+                # of __eq__ and/or __hash__ this is the next best way to test
+                # for object resource equality
+                try:
+                    try:
+                        res = list(filter(lambda x: x.name == item.name, self._assets))[-1]
+                    except IndexError:
+                        # This means the resource doesn't exist at all
+                        # most likely rvalue resource
+                        return None
+                    return self._assets.index(res)
+                except ValueError:
+                    return None
+        elif isinstance(item, Action):
+            try:
+                return self._actions.index(item)
+            except ValueError:
+                # Just in case attempt to locate the resource index by name
+                # since some tasks run in parallel and when they return
+                # the resource object it is a different memory reference.
+                # Since the resource objects don't have an implementation
+                # of __eq__ and/or __hash__ this is the next best way to test
+                # for object resource equality
+                # TODO: Remove the try/except when the resources implement __eq__/__hash__
+                try:
+                    try:
+                        res = list(filter(lambda x: x.name == item.name, self._actions))[-1]
+                    except IndexError:
+                        # This means the resource doesn't exist at all
+                        # most likely rvalue resource
+                        return None
+                    return self._actions.index(res)
+                except ValueError:
+                    return None
+        elif isinstance(item, Execute):
+            try:
+                return self._executes.index(item)
+            except ValueError:
+                # Just in case attempt to locate the resource index by name
+                # since some tasks run in parallel and when they return
+                # the resource object it is a different memory reference.
+                # Since the resource objects don't have an implementation
+                # of __eq__ and/or __hash__ this is the next best way to test
+                # for object resource equality
+                try:
+                    try:
+                        res = list(filter(lambda x: x.name == item.name, self._executes))[-1]
+                    except IndexError:
+                        # This means the resource doesn't exist at all
+                        # most likely rvalue resource
+                        return None
+                    return self._executes.index(res)
+                except ValueError:
+                    return None
+        elif isinstance(item, Report):
+            try:
+                return self._reports.index(item)
+            except ValueError:
+                # Just in case attempt to locate the resource index by name
+                # since some tasks run in parallel and when they return
+                # the resource object it is a different memory reference.
+                # Since the resource objects don't have an implementation
+                # of __eq__ and/or __hash__ this is the next best way to test
+                # for object resource equality
+                try:
+                    try:
+                        res = list(filter(lambda x: x.name == item.name, self._reports))[-1]
+                    except IndexError:
+                        # This means the resource doesn't exist at all
+                        # most likely rvalue resource
+                        return None
+                    return self._reports.index(res)
+                except ValueError:
+                    return None
+        elif isinstance(item, Notification):
+            try:
+                return self._notifications.index(item)
+            except ValueError:
+                # Just in case attempt to locate the resource index by name
+                # since some tasks run in parallel and when they return
+                # the resource object it is a different memory reference.
+                # Since the resource objects don't have an implementation
+                # of __eq__ and/or __hash__ this is the next best way to test
+                # for object resource equality
+                try:
+                    try:
+                        res = list(filter(lambda x: x.name == item.name, self._notifications))[-1]
+                    except IndexError:
+                        # This means the resource doesn't exist at all
+                        # most likely rvalue resource
+                        return None
+                    return self._notifications.index(res)
+                except ValueError:
+                    return None
+        else:
+            raise ValueError('Resource must be of a valid Resource type.'
+                             'Check the type of the given item: %s' % item)
+
+    def replace_resource(self, item, idx):
+        """replace a scenario resource in its corresponding list.
+
+      :param item: resource
+      :type item: object
+      :param idx: index of resource list
+      :type idx: int
+      """
+        if isinstance(item, Asset):
+            self._assets[idx] = item
+        elif isinstance(item, Action):
+            self._actions[idx] = item
+        elif isinstance(item, Execute):
+            self._executes[idx] = item
+        elif isinstance(item, Report):
+            self._reports[idx] = item
+        elif isinstance(item, Notification):
+            self._notifications[idx] = item
+        else:
+            raise ValueError('Resource must be of a valid Resource type.'
+                             'Check the type of the given item: %s' % item)
+
+    def add_resource(self, item, idx=None):
         """Add a scenario resource to its corresponding list.
 
         :param item: resource data
         :type item: object
+        :param idx: index of resource list
+        :type idx: int
         """
         if isinstance(item, Asset):
-            self._assets.append(item)
+            if idx is not None:
+                cur_idx = self.get_resource_idx(item)
+                if cur_idx is not None:
+                    if idx != cur_idx:
+                        idx = cur_idx
+                    self.replace_resource(item=item, idx=idx)
+                else:
+                    self._assets.insert(idx, item)
+            else:
+                self._assets.append(item)
         elif isinstance(item, Action):
-            self._actions.append(item)
+            if idx is not None:
+                cur_idx = self.get_resource_idx(item)
+                if cur_idx is not None:
+                    if idx != cur_idx:
+                        idx = cur_idx
+                    self.replace_resource(item=item, idx=idx)
+                else:
+                    self._actions.insert(idx, item)
+            else:
+                self._actions.append(item)
         elif isinstance(item, Execute):
-            self._executes.append(item)
+            if idx is not None:
+                cur_idx = self.get_resource_idx(item)
+                if cur_idx is not None:
+                    if idx != cur_idx:
+                        idx = cur_idx
+                    self.replace_resource(item=item, idx=idx)
+                else:
+                    self._executes.insert(idx, item)
+            else:
+                self._executes.append(item)
         elif isinstance(item, Report):
-            self._reports.append(item)
+            if idx is not None:
+                cur_idx = self.get_resource_idx(item)
+                if cur_idx is not None:
+                    if idx != cur_idx:
+                        idx = cur_idx
+                    self.replace_resource(item=item, idx=idx)
+                else:
+                    self._reports.insert(idx, item)
+            else:
+                self._reports.append(item)
         elif isinstance(item, Notification):
-            self._notifications.append(item)
+            if idx is not None:
+                cur_idx = self.get_resource_idx(item)
+                if cur_idx is not None:
+                    if idx != cur_idx:
+                        idx = cur_idx
+                    self.replace_resource(item=item, idx=idx)
+                else:
+                    self._notifications.insert(idx, item)
+            else:
+                self._notifications.append(item)
         else:
             raise ValueError('Resource must be of a valid Resource type.'
                              'Check the type of the given item: %s' % item)
@@ -233,100 +413,76 @@ class Scenario(TefloResource):
 
     def reload_resources(self, tasks):
         """Reload scenario resources.
+
         This method is used to reload all resources after they have been processed (provisioned/orchestrate actions/
         execute tests/imported. Prior to adding the resource to the scenario, it filters the list by
         checking if the resource belongs to that scenario by comparing the names.
 
-        Then it filters the task list even more extracting the resource and the data in rvalue.
-        If rvalue is present then linchpin count feature was used and that more new host resources will be
-        created. If rvalue is not present then assume it is either a report resource or from a provisioning perspective
-        linchpin count was either not used (which is equivalent of count==1), or using old provisioners.
+        When filtering we extract the resource, the data in rvalue, and the index the reource is at
+        in the current resource list. If rvalue is present, then a provisioner with count
+        feature was used so more new host resources will be created dynamically as part of this reload.
+        If rvalue is not present then assume it is either a non-Asset resource or from a provisioning perspective
+        count was either not used (which is equivalent of count==1), or using old provisioners so the original
+        resource will be replaced with the updated resource in the task results lists.
 
         :param tasks: task data returned by blaster
         :type tasks: list
         """
-        count = 0
+
         filtered_task_list = list()
-        non_task_assets = list()
-        non_task_package = list()
 
-        # Filtering the resources based on labels. Separate steps for each resources, to make sure same name
-        # collisions dont happen between two different types of resources
+        # This a brute force way of resolving the out of order of resources when using labels.
+        # Prior to this change we would
+        # 1. filter task list for resource type the scenarios has ownership
+        # 2. filter existing resource list for the other resources of the same type that were filtered out by label
+        # 3. re-init the resource list for the resource type with an empty array
+        # 4. Append the resources that were updated from step 1
+        # 5. Then append the rest of the resources from step 2
+        # This lead to the resources being out of order in the results.yml
+        #
+        # Now we keep track of the index of the original resource so that we know where to replace/insert
+        # the new resources or updated resource in the list. This will support when the resource list is
+        # filtered using labels or status so we can retain proper ordering within the resource list during reload.
+        #
+        # New way
+        # 1. filter task list for scenario resource ownership and it's index location in resource list
+        # 2. if rvalue, then the first new resource will replace the original resource at the original index
+        # 3. if rvalue, for each 1+N rvalue will have the index incremented by 1 and inserted at the new index
+        #    pushing any resource that was at the index down the stack.
+        # 4. if not rvalue, the updated resource will check to see if the original resource is at the previous index
+        #    or at a new index (becaue it's been pushed down the stack) and replace the original resource accordingly.
 
+        # TODO: Simplify the filtering of resources when resources implement __eq__/__hash__
         filtered_task_list.extend(
-            [task for task in tasks if task.get('asset') and getattr(task.get('asset'), 'name')
+            [(task, self.get_resource_idx(task.get('asset')))
+             for task in tasks if task.get('asset') and getattr(task.get('asset'), 'name')
              in [h.name for h in self.assets]]
         )
         filtered_task_list.extend(
-            [task for task in tasks if isinstance(task.get('package'), Report) and (getattr(task.get('package'), 'name')
-             in [r.name for r in self.reports])]
+            [(task, self.get_resource_idx(task.get('package')))
+             for task in tasks if isinstance(task.get('package'), Report) and (getattr(task.get('package'), 'name')
+                                                                               in [r.name for r in self.reports])]
         )
 
         filtered_task_list.extend(
-            [task for task in tasks if
+            [(task, self.get_resource_idx(task.get('package'))) for task in tasks if
              isinstance(task.get('package'), Execute) and (getattr(task.get('package'), 'name')
                                                            in [r.name for r in self.executes])]
         )
 
         filtered_task_list.extend(
-            [task for task in tasks if isinstance(task.get('package'), Action) and (getattr(task.get('package'), 'name')
-             in [r.name for r in self.actions])]
+            [(task, self.get_resource_idx(task.get('package')))
+             for task in tasks if isinstance(task.get('package'), Action) and (getattr(task.get('package'), 'name')
+                                                                               in [r.name for r in self.actions])]
         )
 
-        # using labels in SDF will have only specific resources selected. So collecting the non task related
-        # assets and report resources to be added back to the scenario resources. This is being done in order to
-        # put the non provisioned asset and non imported report resources into results.yml
-        non_task_assets.extend([asset for asset in self.assets if asset.name not in
-                                [getattr(task.get('asset'), 'name') for task in filtered_task_list
-                                 if task.get('asset')]])
-
-        non_task_package.extend([report for report in self.reports if report.name not in
-                                 [getattr(task.get('package'), 'name') for task in filtered_task_list if
-                                  isinstance(task.get('package'), Report) and (getattr(task.get('package'), 'name'))]])
-
-        non_task_package.extend([execute for execute in self.executes if execute.name not in
-                                 [getattr(task.get('package'), 'name') for task in filtered_task_list if
-                                  isinstance(task.get('package'), Execute) and (getattr(task.get('package'), 'name'))]])
-
-        non_task_package.extend([action for action in self.actions if action.name not in
-                                 [getattr(task.get('package'), 'name') for task in filtered_task_list if
-                                  isinstance(task.get('package'), Action) and (getattr(task.get('package'), 'name'))]])
-
-        for res, rvalue in [(res, item['rvalue']) for task in filtered_task_list
-                            for res in [task.get(r) for r in ['asset', 'package'] if r in task.keys()]
-                            for item in task.get('methods')]:
-            if count == 0:
-                if rvalue is not None:
-                    # initialize the host resource list to remove any previous host resources
-                    self.initialize_resource(res)
-                    # load the new host resources using the parameters from item['rvalue']
-                    self.load_resources(Asset, rvalue)
-                    count += 1
-                else:
-                    self.initialize_resource(res)
-                    self.add_resource(res)
-                    count += 1
+        for res, rvalue, idx in [(res, item['rvalue'], idx) for task, idx in filtered_task_list
+                                 for res in [task.get(r) for r in ['asset', 'package'] if r in task.keys()]
+                                 for item in task.get('methods')]:
+            if rvalue is not None:
+                self.load_resources(Asset, rvalue, idx)
             else:
-                if rvalue is not None:
-                    self.load_resources(Asset, rvalue)
-                else:
-                    self.add_resource(res)
-
-        if count > 0:
-            task_keys = list()
-            task_keys.extend([k for task in tasks for k in task.keys()])
-            if 'asset' in task_keys:
-                # Adding assets which were not part of the labels used
-                for res in non_task_assets:
-                    self.add_resource(res)
-            elif 'package' in task_keys:
-                # Adding other resources except asset which were not part of the labels used
-                # getting the type of resource is the tasks list and comparing it with the non_task_resources
-                # if they are of same type then add the resource else pass
-                pkg_type = type(tasks[0].get('package'))
-                for res in non_task_package:
-                    if isinstance(res, pkg_type):
-                        self.add_resource(res)
+                self.add_resource(res, idx)
 
         return
 
@@ -581,7 +737,7 @@ class Scenario(TefloResource):
         }
         return task
 
-    def load_resources(self, res_type, res_list):
+    def load_resources(self, res_type, res_list, idx=None):
         """
         Load the resource in the scenario list of `res_type`.
 
@@ -598,13 +754,18 @@ class Scenario(TefloResource):
         :param res_type: The type of resources the function will load into its
             list
         :param res_list: A list of resources dict
+        :param idx: integer index where resource will be replaced/insert
         :return: None
         """
         # No resources defined, then exit
         if not res_list:
             return
-
+        increment = False
         for item in res_list:
-            self.add_resource(
-                res_type(config=self.config,
-                         parameters=item))
+            if idx is not None and not increment:
+                self.replace_resource(item=res_type(config=self.config, parameters=item), idx=idx)
+                increment = True
+                continue
+            if idx is not None and increment:
+                idx += 1
+            self.add_resource(item=res_type(config=self.config, parameters=item), idx=idx)

--- a/tests/functional/test_resources.py
+++ b/tests/functional/test_resources.py
@@ -62,30 +62,36 @@ def feature_toggle_config():
 @pytest.fixture
 def default_report_params():
     params = dict(
-                  description='description',
-                  executes='execute',
-                  provider=dict(name='polarion',
-                                credential='polarion'
-                                )
-                  )
+        description='description',
+        executes='execute',
+        provider=dict(name='polarion',
+                      credential='polarion'
+                      )
+    )
     return params
 
 
 @pytest.fixture
 def report_params_np():
     params = dict(
-                  description='description',
-                  executes='execute',
-                  importer='polarion',
-                  credential='polarion'
-                  )
+        description='description',
+        executes='execute',
+        importer='polarion',
+        credential='polarion'
+    )
     return params
 
 
 @pytest.fixture
-def host1(default_host_params, config):
-    host1 = Asset(name='host_count', config=config, parameters=copy.deepcopy(default_host_params))
-    return host1
+def host2(default_host_params, config):
+    host2 = Asset(name='host_count', config=config, parameters=copy.deepcopy(default_host_params))
+    return host2
+
+
+@pytest.fixture
+def host3(default_host_params, config):
+    host3 = Asset(name='host_number_3', config=config, parameters=copy.deepcopy(default_host_params))
+    return host3
 
 
 @pytest.fixture
@@ -94,33 +100,63 @@ def host1(default_host_params, config):
 def report1(mock_plugin_class, mock_plugin_list, default_report_params, config):
     mock_plugin_list.return_value = ['polarion']
     mock_plugin_class.return_value = ImporterPlugin
-    return Report(name='SampleTest.xml', parameters=default_report_params, config=config)
+    return Report(name='SampleTest.xml', parameters=copy.deepcopy(default_report_params), config=config)
 
 
 @pytest.fixture
-def scenario_res1(config, host1, host, report1):
+@mock.patch('teflo.resources.reports.get_importers_plugin_list')
+@mock.patch('teflo.resources.reports.get_importer_plugin_class')
+def report2(mock_plugin_class, mock_plugin_list, default_report_params, config):
+    mock_plugin_list.return_value = ['polarion']
+    mock_plugin_class.return_value = ImporterPlugin
+    return Report(name='SampleTest2.xml', parameters=copy.deepcopy(default_report_params), config=config)
+
+
+@pytest.fixture
+@mock.patch('teflo.resources.reports.get_importers_plugin_list')
+@mock.patch('teflo.resources.reports.get_importer_plugin_class')
+def report3(mock_plugin_class, mock_plugin_list, default_report_params, config):
+    mock_plugin_list.return_value = ['polarion']
+    mock_plugin_class.return_value = ImporterPlugin
+    return Report(name='SampleTest3.xml', parameters=copy.deepcopy(default_report_params), config=config)
+
+
+@pytest.fixture
+def scenario_res1(config, host2, host, report1):
     scenario1 = Scenario(config=config, parameters={'k': 'v'})
-    scenario1.add_assets(host1)
+    scenario1.add_assets(host2)
     scenario1.add_assets(host)
     scenario1.add_reports(report1)
     return scenario1
 
 
 @pytest.fixture
-def scenario_res2(config, host1, host, report1):
+def scenario_res2(config, host2, host, report1):
     scenario1 = Scenario(config=config, parameters={'k': 'v'})
-    scenario1.add_assets(host1)
+    scenario1.add_assets(host2)
     scenario1.add_assets(host)
     scenario1.add_reports(report1)
     return scenario1
 
 
 @pytest.fixture
-def task_list_host(host1, host):
+def scenario_res3(config, host2, host, host3, report1, report2, report3):
+    scenario1 = Scenario(config=config, parameters={'k': 'v'})
+    scenario1.add_assets(host3)
+    scenario1.add_assets(host2)
+    scenario1.add_assets(host)
+    scenario1.add_reports(report1)
+    scenario1.add_reports(report2)
+    scenario1.add_reports(report3)
+    return scenario1
 
-    param1 = copy.deepcopy(host1.profile())
+
+@pytest.fixture
+def task_list_host(host2, host):
+
+    param1 = copy.deepcopy(host2.profile())
     param1.update(name='host_count_0')
-    param2 = copy.deepcopy(host1.profile())
+    param2 = copy.deepcopy(host2.profile())
     param2.update(name='host_count_1')
 
     task_result_list = [
@@ -128,7 +164,7 @@ def task_list_host(host1, host):
          'task': 'teflotaskobj1',
          'methods': [{'status': 0, 'rvalue': [param1, param2], 'name':'run'}],
          'bid': 123,
-         'asset': host1,
+         'asset': host2,
          'msg': 'hostcreation1'
          },
         {'status': 0,
@@ -144,11 +180,11 @@ def task_list_host(host1, host):
 
 
 @pytest.fixture
-def task_list_host_1(host1):
+def task_list_host_1(host2):
 
-    param1 = copy.deepcopy(host1.profile())
+    param1 = copy.deepcopy(host2.profile())
     param1.update(name='host_count_0')
-    param2 = copy.deepcopy(host1.profile())
+    param2 = copy.deepcopy(host2.profile())
     param2.update(name='host_count_1')
 
     task_result_list = [
@@ -156,8 +192,74 @@ def task_list_host_1(host1):
          'task': 'teflotaskobj1',
          'methods': [{'status': 0, 'rvalue': [param1, param2], 'name':'run'}],
          'bid': 123,
-         'asset': host1,
+         'asset': host2,
          'msg': 'hostcreation1'
+         }
+
+    ]
+
+    return task_result_list
+
+@pytest.fixture
+def task_list_host_with_3(host2, host, host3):
+
+    param1 = copy.deepcopy(host2.profile())
+    param1.update(name='host_count_0')
+    param2 = copy.deepcopy(host2.profile())
+    param2.update(name='host_count_1')
+
+    task_result_list = [
+        {'status': 0,
+         'task': 'teflotaskobj3',
+         'methods': [{'status': 0, 'rvalue': None, 'name':'run'}],
+         'bid': 789,
+         'asset': host3,
+         'msg': 'hostcreation3'
+         },
+        {'status': 0,
+         'task': 'teflotaskobj1',
+         'methods': [{'status': 0, 'rvalue': [param1, param2], 'name':'run'}],
+         'bid': 123,
+         'asset': host2,
+         'msg': 'hostcreation1'
+         },
+        {'status': 0,
+         'task': 'teflotaskobj2',
+         'methods': [{'status': 0, 'rvalue': None, 'name':'run'}],
+         'bid': 456,
+         'asset': host,
+         'msg': 'hostcreation2'
+         }
+
+    ]
+
+    return task_result_list
+
+
+@pytest.fixture
+def task_list_host_with_3_no_count(host2, host, host3):
+
+    task_result_list = [
+        {'status': 0,
+         'task': 'teflotaskobj3',
+         'methods': [{'status': 0, 'rvalue': None, 'name':'run'}],
+         'bid': 789,
+         'asset': host3,
+         'msg': 'hostcreation3'
+         },
+        {'status': 0,
+         'task': 'teflotaskobj1',
+         'methods': [{'status': 0, 'rvalue': None, 'name':'run'}],
+         'bid': 123,
+         'asset': host2,
+         'msg': 'hostcreation1'
+         },
+        {'status': 0,
+         'task': 'teflotaskobj2',
+         'methods': [{'status': 0, 'rvalue': None, 'name':'run'}],
+         'bid': 456,
+         'asset': host,
+         'msg': 'hostcreation2'
          }
 
     ]
@@ -169,16 +271,44 @@ def task_list_host_1(host1):
 def task_list_report(report1):
 
     task_result_list = [
-                         {'status': 0,
-                          'task': 'ReportTask',
-                          'methods': [{'status': 0, 'rvalue': None, 'name': 'run'}],
-                          'package': report1,
-                          'bid': 234,
-                          'msg': 'reporting SampleTest.xml', 'name': 'SampleTest.xml'
-                         }
-                        ]
+        {'status': 0,
+         'task': 'ReportTask',
+         'methods': [{'status': 0, 'rvalue': None, 'name': 'run'}],
+         'package': report1,
+         'bid': 234,
+         'msg': 'reporting SampleTest.xml', 'name': 'SampleTest.xml'
+         }
+    ]
     return task_result_list
 
+
+@pytest.fixture
+def task_list_report_2(report1, report2, report3):
+
+    task_result_list = [
+        {'status': 0,
+         'task': 'ReportTask',
+         'methods': [{'status': 0, 'rvalue': None, 'name': 'run'}],
+         'package': report1,
+         'bid': 234,
+         'msg': 'reporting SampleTest.xml', 'name': 'SampleTest.xml'
+         },
+        {'status': 0,
+         'task': 'ReportTask',
+         'methods': [{'status': 0, 'rvalue': None, 'name': 'run'}],
+         'package': report2,
+         'bid': 101,
+         'msg': 'reporting SampleTest2.xml', 'name': 'SampleTest2.xml'
+         },
+        {'status': 0,
+         'task': 'ReportTask',
+         'methods': [{'status': 0, 'rvalue': None, 'name': 'run'}],
+         'package': report3,
+         'bid': 222,
+         'msg': 'reporting SampleTest3.xml', 'name': 'SampleTest3.xml'
+         }
+    ]
+    return task_result_list
 
 class TestActionResource(object):
     @staticmethod
@@ -194,7 +324,7 @@ class TestActionResource(object):
     def test_timeout_from_scenario(timeout_param_orchestrate):
         action = Action(name='action', parameters=timeout_param_orchestrate)
         assert action._orchestrate_timeout is 20
-    
+
     @staticmethod
     def test_timeout_from_cfg(config):
         params = dict(
@@ -397,12 +527,12 @@ class TestExecuteResource(object):
         with pytest.raises(TefloExecuteError) as ex:
             Execute()
         assert 'Unable to build execute object. Name field missing!' in \
-            ex.value.args
+               ex.value.args
     @staticmethod
     def test_timeout_from_scenario(timeout_param_execute):
         execute = Execute(name='action', parameters=timeout_param_execute)
         assert execute._execute_timeout is 20
-    
+
     @staticmethod
     def test_timeout_from_cfg(config, default_host_params):
         params = dict(hosts=['host01'], key='value')
@@ -619,12 +749,45 @@ class TestScenarioResource(object):
     def test_reload_method_assets_mixed_tasks(task_list_host, scenario_res1):
         scenario_res1.reload_resources(task_list_host)
         assert len(scenario_res1.assets) == 3
+        assert scenario_res1.assets[0].name == 'host_count_0'
+        assert scenario_res1.assets[1].name == 'host_count_1'
+        assert scenario_res1.assets[2].name == 'host01'
+
+    @staticmethod
+    def test_reload_method_default(task_list_host_with_3_no_count, scenario_res3):
+        scenario_res3.reload_resources(task_list_host_with_3_no_count)
+        assert len(scenario_res3.assets) == 3
+        assert scenario_res3.assets[0].name == 'host_number_3'
+        assert scenario_res3.assets[1].name == 'host_count'
+        assert scenario_res3.assets[2].name == 'host01'
 
     @staticmethod
     def test_reload_method_assets_reversed_mixed_tasks(task_list_host, scenario_res2):
         task_list_host.reverse()
         scenario_res2.reload_resources(task_list_host)
         assert len(scenario_res2.assets) == 3
+        assert scenario_res2.assets[0].name == 'host_count_0'
+        assert scenario_res2.assets[1].name == 'host_count_1'
+        assert scenario_res2.assets[2].name == 'host01'
+
+    @staticmethod
+    def test_reload_method_assets_count_from_middle_tasks(task_list_host_with_3, scenario_res3):
+        scenario_res3.reload_resources(task_list_host_with_3)
+        assert len(scenario_res3.assets) == 4
+        assert scenario_res3.assets[0].name == 'host_number_3'
+        assert scenario_res3.assets[1].name == 'host_count_0'
+        assert scenario_res3.assets[2].name == 'host_count_1'
+        assert scenario_res3.assets[3].name == 'host01'
+
+    @staticmethod
+    def test_reload_method_assets_count_reversed_from_middle_tasks(task_list_host_with_3, scenario_res3):
+        task_list_host_with_3.reverse()
+        scenario_res3.reload_resources(task_list_host_with_3)
+        assert len(scenario_res3.assets) == 4
+        assert scenario_res3.assets[0].name == 'host_number_3'
+        assert scenario_res3.assets[1].name == 'host_count_0'
+        assert scenario_res3.assets[2].name == 'host_count_1'
+        assert scenario_res3.assets[3].name == 'host01'
 
     @staticmethod
     def test_reload_method_reports_tasks(task_list_report, scenario_res1):
@@ -632,12 +795,44 @@ class TestScenarioResource(object):
         assert len(scenario_res1.reports) == 1
 
     @staticmethod
+    def test_reload_method_reports_reversed_tasks(task_list_report_2, scenario_res3):
+        task_list_report_2.reverse()
+        scenario_res3.reload_resources(task_list_report_2)
+        assert len(scenario_res3.reports) == 3
+        assert scenario_res3.reports[0].name == 'SampleTest.xml'
+        assert scenario_res3.reports[1].name == 'SampleTest2.xml'
+        assert scenario_res3.reports[2].name == 'SampleTest3.xml'
+
+    @staticmethod
     def test_reload_method_assets_tasks_using_labels(task_list_host_1, scenario_res1):
         """This is to test if assets which are not picked up for a task still get added to the scenario to populate
          the results.yml"""
         scenario_res1.reload_resources(task_list_host_1)
         assert len(scenario_res1.assets) == 3
+        assert scenario_res1.assets[0].name == 'host_count_0'
+        assert scenario_res1.assets[1].name == 'host_count_1'
+        assert scenario_res1.assets[2].name == 'host01'
 
+    @staticmethod
+    def test_reload_method_assets_tasks_using_labels_and_asset_count(task_list_host_1, scenario_res3):
+        """This is to test if assets which are not picked up for a task still get added to the scenario to populate
+         the results.yml"""
+        scenario_res3.reload_resources(task_list_host_1)
+        assert len(scenario_res3.assets) == 4
+        assert scenario_res3.assets[0].name == 'host_number_3'
+        assert scenario_res3.assets[1].name == 'host_count_0'
+        assert scenario_res3.assets[2].name == 'host_count_1'
+        assert scenario_res3.assets[3].name == 'host01'
+
+    @staticmethod
+    def test_reload_method_reports_tasks_using_labels(task_list_report_2, scenario_res3):
+        """This is to test if assets which are not picked up for a task still get added to the scenario to populate
+         the results.yml"""
+        scenario_res3.reload_resources(task_list_report_2[1:2])
+        assert len(scenario_res3.reports) == 3
+        assert scenario_res3.reports[0].name == 'SampleTest.xml'
+        assert scenario_res3.reports[1].name == 'SampleTest2.xml'
+        assert scenario_res3.reports[2].name == 'SampleTest3.xml'
 
 class TestAssetResource(object):
     @staticmethod
@@ -648,7 +843,7 @@ class TestAssetResource(object):
     def test_timeout_from_scenario(timeout_param_provision, config):
         asset = Asset(name='Asset', parameters=timeout_param_provision, config=config)
         assert asset._provision_timeout is 20
-    
+
     @staticmethod
     def test_timeout_from_cfg(default_host_params, config):
         params = default_host_params


### PR DESCRIPTION
 * Should resolve issue #93 where resources in the results.yml
   were ending up out of proper order when either using labels
   or resource status. It should work for both when the
   resources are need to be reloaded when blaster tasks have been
   run in parallel or sequential.

 * Also included tests to better capture the different variations