### PR TITLE
Convert beaker provisioner total attempts to an integer data type

### DIFF
--- a/teflo/provisioners/ext/bkr_client_plugin/beaker_client_plugin.py
+++ b/teflo/provisioners/ext/bkr_client_plugin/beaker_client_plugin.py
@@ -224,7 +224,7 @@ class BeakerClientProvisionerPlugin(ProvisionerPlugin):
         self.logger.debug('Beaker timeout limit: %s.' % wait)
 
         # check Beaker status every 60 seconds
-        total_attempts = wait / 60
+        total_attempts = int(wait / 60)
 
         attempt = 0
         while wait > 0:


### PR DESCRIPTION
Converts the total attempts to wait for a beaker job to finish from a float to an integer. It makes the logging look a bit cleaner.

**Before**

```
2021-07-24 14:01:17,287 INFO                                TEFLO RUN (START)                               
2021-07-24 14:01:17,287 INFO -------------------------------------------------------------------------------
2021-07-24 14:01:17,288 INFO  * Data Folder           : /var/lib/jenkins/workspace/gs-openshift4.8-cnv2.6-odf4.7-rywillia/.teflo/73uiac1mt6
2021-07-24 14:01:17,288 INFO  * Workspace             : .
2021-07-24 14:01:17,288 INFO  * Log Level             : info
2021-07-24 14:01:17,288 INFO  * Tasks                 : ['provision']
2021-07-24 14:01:17,289 INFO  * Scenario              : libvirt_stack
2021-07-24 14:01:17,289 INFO  * Included Scenario(s)  : ['provision_localhost', 'provision_libvirt', 'orchestrate_stack']
2021-07-24 14:01:17,289 INFO -------------------------------------------------------------------------------

2021-07-24 14:01:17,290 INFO  * Task    : provision
2021-07-24 14:01:17,290 INFO Sending out any notifications that are registered.
2021-07-24 14:01:17,291 INFO ..................................................
2021-07-24 14:01:17,291 INFO Starting tasks on pipeline: notify
2021-07-24 14:01:17,292 WARNING ... no tasks to be executed ...
2021-07-24 14:01:17,293 INFO ..................................................
2021-07-24 14:01:17,293 INFO Starting tasks on pipeline: provision
2021-07-24 14:01:17,293 INFO --> Blaster v0.4.0 <--
2021-07-24 14:01:17,294 INFO Task Execution: Concurrent
2021-07-24 14:01:17,297 INFO Tasks:
2021-07-24 14:01:17,297 INFO 1. Task     : scenario_driver
                                Class    : <class 'teflo.tasks.provision.ProvisionTask'>
                                Methods  : ['run']
2021-07-24 14:01:17,299 INFO 2. Task     : baremetal
                                Class    : <class 'teflo.tasks.provision.ProvisionTask'>
                                Methods  : ['run']
2021-07-24 14:01:17,299 INFO ** BLASTER BEGIN **
2021-07-24 14:01:17,316 WARNING Asset scenario_driver is static, provision will be skipped.
2021-07-24 14:01:17,327 INFO Beaker config already exists, skip creation.
2021-07-24 14:01:17,329 INFO    provisioning asset baremetal
2021-07-24 14:01:17,329 INFO Provisioning asset baremetal.
2021-07-24 14:01:18,432 INFO Connected to beaker!
2021-07-24 14:01:18,434 INFO Generating beaker job XML..
2021-07-24 14:01:19,391 INFO Successfully generated beaker job XML!
2021-07-24 14:01:19,392 INFO Submitting beaker job XML..
2021-07-24 14:01:20,272 INFO Beaker job ID: J:5621156.
2021-07-24 14:01:20,273 INFO Beaker job URL: https://****/jobs/5621156.
2021-07-24 14:01:20,274 INFO Successfully submitted beaker XML!
2021-07-24 14:01:20,275 INFO Waiting for machine to be ready, attempt 1 of 480.0.
2021-07-24 14:01:20,831 INFO Beaker Job: id: J:5621156 status: wait.
2021-07-24 14:02:20,878 INFO Waiting for machine to be ready, attempt 2 of 480.0.
```

**After**

```
2021-08-19 16:41:28,752 INFO                                TEFLO RUN (START)                               
2021-08-19 16:41:28,753 INFO -------------------------------------------------------------------------------
2021-08-19 16:41:28,753 INFO  * Data Folder           : .teflo/34hlned1x9
2021-08-19 16:41:28,753 INFO  * Workspace             : /home/rywillia/Projects/gitlab/mpqe/mps/cnv_odf_ocp/venv2/cnv_odf_ocp
2021-08-19 16:41:28,754 INFO  * Log Level             : info
2021-08-19 16:41:28,754 INFO  * Tasks                 : ['provision']
2021-08-19 16:41:28,754 INFO  * Scenario              : libvirt_stack
2021-08-19 16:41:28,754 INFO  * Included Scenario(s)  : ['provision_localhost', 'provision_libvirt', 'orchestrate_stack']
2021-08-19 16:41:28,755 INFO -------------------------------------------------------------------------------

2021-08-19 16:41:28,755 INFO  * Task    : provision
2021-08-19 16:41:28,755 INFO Sending out any notifications that are registered.
2021-08-19 16:41:28,756 INFO ..................................................
2021-08-19 16:41:28,756 INFO Starting tasks on pipeline: notify
2021-08-19 16:41:28,757 WARNING ... no tasks to be executed ...
2021-08-19 16:41:28,757 INFO ..................................................
2021-08-19 16:41:28,757 INFO Starting tasks on pipeline: provision
2021-08-19 16:41:28,758 INFO --> Blaster v0.4.0 <--
2021-08-19 16:41:28,758 INFO Task Execution: Concurrent
2021-08-19 16:41:28,772 INFO Tasks:
2021-08-19 16:41:28,772 INFO 1. Task     : scenario_driver
                                Class    : <class 'teflo.tasks.provision.ProvisionTask'>
                                Methods  : ['run']
2021-08-19 16:41:28,774 INFO 2. Task     : baremetal
                                Class    : <class 'teflo.tasks.provision.ProvisionTask'>
                                Methods  : ['run']
2021-08-19 16:41:28,776 INFO ** BLASTER BEGIN **
2021-08-19 16:41:28,792 INFO Beaker config already exists, skip creation.
2021-08-19 16:41:28,792 WARNING Asset scenario_driver is static, provision will be skipped.
2021-08-19 16:41:28,793 INFO    provisioning asset baremetal
2021-08-19 16:41:28,794 INFO Provisioning asset baremetal.
2021-08-19 16:41:30,289 INFO Connected to beaker!
2021-08-19 16:41:30,290 INFO Generating beaker job XML..
2021-08-19 16:41:31,592 INFO Successfully generated beaker job XML!
2021-08-19 16:41:31,592 INFO Submitting beaker job XML..
2021-08-19 16:41:32,706 INFO Beaker job ID: J:5722004.
2021-08-19 16:41:32,707 INFO Beaker job URL: https://****/jobs/5722004.
2021-08-19 16:41:32,708 INFO Successfully submitted beaker XML!
2021-08-19 16:41:32,709 INFO Waiting for machine to be ready, attempt 1 of 480.
2021-08-19 16:41:33,305 INFO Beaker Job: id: J:5722004 status: wait.
```