### PR TITLE
Allow users to set ansible verbosity using ansible environment variable

### DIFF
--- a/docs/users/definitions/orchestrate.rst
+++ b/docs/users/definitions/orchestrate.rst
@@ -199,8 +199,11 @@ teflo.cfg file.  The following are the settings.
           verbosity is 'vvvv'.
 
 .. note::
-        If incorrect value for verbosity is set in teflo.cfg, Teflo changes the verbosity based on
-        teflo's logging level
+        Teflo can consume the Ansible verbosity level using Ansible's built-in environment variable
+        `ANSIBLE_VERBOSITY <https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-verbosity>`_
+        in addition to consuming it from being defined within teflo.cfg file. If
+        the verbosity value is incorrect within teflo.cfg, teflo will default to the verbosity based
+        on teflo's logging level.
 
 Ansible Configuration
 ~~~~~~~~~~~~~~~~~~~~~

--- a/tests/functional/test_helpers.py
+++ b/tests/functional/test_helpers.py
@@ -458,6 +458,20 @@ def test_ansible_verbosity_5(config):
     assert get_ans_verbosity(config) == 'vvvv'
 
 
+def test_ansible_verbosity_6(config):
+    """This test verifies the get_ans_verbosity func can lookup ansible verbosity by environment variable."""
+    del config["ANSIBLE_VERBOSITY"]
+
+    with mock.patch.dict(os.environ, {"ANSIBLE_VERBOSITY": "2"}):
+        assert get_ans_verbosity(config) == "vv"
+
+    with mock.patch.dict(os.environ, {"ANSIBLE_VERBOSITY": "5"}):
+        assert get_ans_verbosity(config) is None
+
+    with mock.patch.dict(os.environ, {"ANSIBLE_VERBOSITY": "vvvv"}):
+        assert get_ans_verbosity(config) is None
+
+
 def test_schema_validator_no_creds():
     params = dict(key1='val1', key2=['val2', 'val3'])
     schema_validator(schema_data=params, schema_files=[os.path.abspath('../assets/schemas/schema_test.yml')])


### PR DESCRIPTION
This PR allows teflo users with the ability to set Ansible verbosity using the built-in supported `ANSIBLE_VERBOSITY` environment variable [1]. It is an addition to the existing options for how teflo users can control the ansible verbosity.

[1] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-verbosity