### PR TITLE
CCITCARBON-309 make env variables available during Orchestrate and execute stage of Teflo run

### DIFF
--- a/docs/users/definitions/execute.rst
+++ b/docs/users/definitions/execute.rst
@@ -135,10 +135,17 @@ Please see the table below to understand the key/values defined.
         - n/a
 
     *   - ansible_options
-        - git information for the tests in execution
-        - dictionary of ansible options
+        - get ansible options for the tests in execution
+        - dictionary
         - No
         - n/a
+
+    *   - environment_vars
+        - Additional environment variables to be passed during the test execution
+        - dict
+        - No
+        - environment variables set prior to starting the teflo run are available
+
 
 
 Hosts
@@ -519,6 +526,15 @@ following setting to False in the teflo.cfg
 
    Teflo expects the xmls collected to have the **<testsuites>** tag  OR **<testsuite>** as its root tag,
    else it skips those xml files for testrun summary generation
+
+Using environment variables:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In the below example the environment variables data_dir and uname are made available during
+the playbook execution
+
+.. literalinclude:: ../../../examples/docs-usage/execute.yml
+    :lines: 271-288
 
 Common Examples
 ---------------

--- a/docs/users/definitions/orchestrate.rst
+++ b/docs/users/definitions/orchestrate.rst
@@ -50,6 +50,12 @@ understand the key/values defined.
         - Yes
         - n/a
 
+    *   - environment_vars
+        - Additional environment variables to be passed during the orchestrate task
+        - dict
+        - No
+        - environment variables set prior to starting the teflo run are available
+
 Hosts
 -----
 
@@ -777,6 +783,16 @@ provide the script parameters
 
 .. literalinclude:: ../../../examples/docs-usage/orchestrate.yml
     :lines: 286-294
+
+Example 16
+~~~~~~~~~~
+
+Example to use environment_vars to be passed to the ansible playbook/script/command
+Variables X and Y are available during the script execution and can be retrieved
+for additional logic within the script
+
+.. literalinclude:: ../../../examples/docs-usage/orchestrate.yml
+    :lines: 366-375
 
 Resources
 ~~~~~~~~~

--- a/examples/docs-usage/execute.yml
+++ b/examples/docs-usage/execute.yml
@@ -267,3 +267,22 @@ execute:
       - artifacts/dir1/abc.log
 
 
+# example for env vars
+---
+execute:
+  - name: playbook execution
+    description: "execute playbook tests against the clients"
+    hosts: clients
+    executor: runner
+    playbook:
+    - name: ansible/test_gather_machine_facts.yml
+    ansible_options:
+      extra_vars:
+        workspace: .
+      skip_tags:
+       - cleanup
+    artifacts:
+    - ~/cloud-user/client.facts
+    environment_vars:
+      data_dir: /home/data
+      uname: teflo_user

--- a/examples/docs-usage/orchestrate.yml
+++ b/examples/docs-usage/orchestrate.yml
@@ -361,3 +361,15 @@ orchestrate:
     hosts: localhost
     ansible_playbook:
       name: ansible/mock_kernel_update.yml
+
+# Example 16
+---
+- name: scripta_task
+  description: ""
+  orchestrator: ansible
+  hosts: controller
+  ansible_script:
+    name: scripts/add_two_numbers.sh
+  environment_vars:
+    X: 12
+    Y: 18

--- a/teflo/ansible_helpers.py
+++ b/teflo/ansible_helpers.py
@@ -225,7 +225,7 @@ class AnsibleService(object):
 
     playbook_name = Template("cbn_execute_$type$uid.yml")
 
-    def __init__(self, config, hosts, all_hosts, ansible_options, galaxy_options=None, concurrency=None):
+    def __init__(self, config, hosts, all_hosts, ansible_options, galaxy_options=None, concurrency=None, env_var={}):
         self.hosts = hosts
         self.all_hosts = all_hosts
         self.config = config
@@ -236,7 +236,12 @@ class AnsibleService(object):
         # uuid that we can append to playbook and results file in case
         # execute/orchestrate tasks run concurrently
         self.uid = gen_random_str(5)
-        self.env_var = None
+        # setting the env variables for ansible with the os.environ
+        self.env_var = os.environ
+        if env_var:
+            # Adding any user defined env var to the os.environ
+            self.env_var = self.env_var.update(env_var)
+
         self.ans_log_path = ''
 
         # Setting ANSIBLE_LOG_PATH env variable when running actions concurrently, so each action logs gets
@@ -244,7 +249,7 @@ class AnsibleService(object):
         if concurrency == 'true':
             ans_log = 'ansible_' + self.uid + '.log'
             self.ans_log_path = os.path.join(self.config['WORKSPACE'], ans_log)
-            self.env_var = {'ANSIBLE_LOG_PATH': self.ans_log_path}
+            self.env_var.update({'ANSIBLE_LOG_PATH': self.ans_log_path})
 
         # passing the teflo's inventory directory to the Ansible Controller
         self.ans_controller = AnsibleController(os.path.abspath(self.config['INVENTORY_FOLDER']))

--- a/teflo/executors/ext/ansible_executor_plugin/ansible_executor_plugin.py
+++ b/teflo/executors/ext/ansible_executor_plugin/ansible_executor_plugin.py
@@ -27,6 +27,7 @@
 
 import ast
 import os.path
+import os
 import textwrap
 from teflo.core import ExecutorPlugin
 from teflo.exceptions import ArchiveArtifactsError, TefloExecuteError, AnsibleServiceError
@@ -67,11 +68,12 @@ class AnsibleExecutorPlugin(ExecutorPlugin):
         self.options = getattr(package, 'ansible_options', None)
         self.ignorerc = getattr(package, 'ignore_rc', False)
         self.validrc = getattr(package, 'valid_rc', None)
-
+        self.env_var = getattr(package, 'environment_vars', {})
         self.injector = DataInjector(self.all_hosts)
 
         self.ans_service = AnsibleService(self.config, self.hosts, self.all_hosts, self.options,
-                                          concurrency=self.config['TASK_CONCURRENCY']['EXECUTE'].lower())
+                                          concurrency=self.config['TASK_CONCURRENCY']['EXECUTE'].lower(),
+                                          env_var=self.env_var)
 
         self.ans_verbosity = get_ans_verbosity(self.config)
 

--- a/teflo/executors/ext/ansible_executor_plugin/files/schema.yml
+++ b/teflo/executors/ext/ansible_executor_plugin/files/schema.yml
@@ -102,3 +102,7 @@ mapping:
       - type: str
   ignore_rc:
     type: bool
+  environment_vars:
+    allowempty: True
+    type: map
+

--- a/teflo/orchestrators/ext/ansible_orchestrator_plugin/ansible_orchestrator_plugin.py
+++ b/teflo/orchestrators/ext/ansible_orchestrator_plugin/ansible_orchestrator_plugin.py
@@ -59,6 +59,7 @@ class AnsibleOrchestratorPlugin(OrchestratorPlugin):
         self.script = getattr(package, 'ansible_script', None)
         self.shell = getattr(package, 'ansible_shell', None)
         self.all_hosts = getattr(package, 'all_hosts', [])
+        self.env_var = getattr(package, 'environment_vars', {})
 
         # calling the method to do a backward compatibility check in case user is defining name field as a path for
         # script or playbook
@@ -68,7 +69,8 @@ class AnsibleOrchestratorPlugin(OrchestratorPlugin):
         # ansible service object
         self.ans_service = AnsibleService(self.config, self.hosts, self.all_hosts,
                                           self.options, self.galaxy_options,
-                                          concurrency=self.config['TASK_CONCURRENCY']['ORCHESTRATE'].lower())
+                                          concurrency=self.config['TASK_CONCURRENCY']['ORCHESTRATE'].lower(),
+                                          env_var=self.env_var)
 
     def backwards_compat_check(self):
         """ This method is put in place to check if any older ways of assigning ansible_playbook/script names are

--- a/teflo/orchestrators/ext/ansible_orchestrator_plugin/files/schema.yml
+++ b/teflo/orchestrators/ext/ansible_orchestrator_plugin/files/schema.yml
@@ -50,3 +50,6 @@ mapping:
   ansible_galaxy_options:
     allowempty: True
     type: map
+  environment_vars:
+    allowempty: True
+    type: map

--- a/tests/functional/test_ansible_helpers.py
+++ b/tests/functional/test_ansible_helpers.py
@@ -70,7 +70,7 @@ class TestAnsibleService(object):
         results = ansible_service.run_playbook(playbook)
         mock_method.assert_called_with(playbook='cbn_execute_script_' + ansible_service.uid + '.yml',
                                        logger=logger, extra_vars=None,
-                                       run_options=None, ans_verbosity=ans_verbosity, env_var=None)
+                                       run_options=None, ans_verbosity=ans_verbosity, env_var=os.environ)
 
     @staticmethod
     @mock.patch.object(AnsibleController, 'run_playbook')
@@ -81,7 +81,7 @@ class TestAnsibleService(object):
         ans_verbosity = ansible_service.ans_verbosity
         results = ansible_service.run_playbook(playbook)
         mock_method.assert_called_with(playbook='hello.yml',logger=logger, extra_vars=extra_vars, run_options={},
-                                       ans_verbosity=ans_verbosity, env_var=None)
+                                       ans_verbosity=ans_verbosity, env_var=os.environ)
 
 
     @staticmethod

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -279,6 +279,9 @@ class TestCli(object):
             teflo, ['run', '-s', '../localhost_scenario/scenario_local.yml', '-im', 'by_wrong']
         )
         assert results.exit_code == 2
+
+    @staticmethod
+    @mock.patch.object(Teflo, 'run')
     def test_wrong_cli_skip_fail(mock_method, runner):
         """This is for testing use of wrong skip_fail option in teflo cli"""
         mock_method.return_value = 0

--- a/tests/localhost_scenario/ansible/variable_test_playbook.yml
+++ b/tests/localhost_scenario/ansible/variable_test_playbook.yml
@@ -11,3 +11,8 @@
 
   - name: print user name
     shell: "echo {{ name }}"
+
+
+  - name: get env vars
+    shell: "echo {{ lookup('env', 'uname') }}, {{ lookup('env', 'project') }} "
+

--- a/tests/localhost_scenario/scenario_local.yml
+++ b/tests/localhost_scenario/scenario_local.yml
@@ -114,6 +114,7 @@ orchestrate:
     ansible_playbook:
       name: ansible/template_host_test_playbook_tasks.yml
 
+  # testing variable files usage and environment variables usage
   - name: playbook_2
     description: "run orchestrate step using file key (list) as extra_vars"
     orchestrator: ansible
@@ -124,6 +125,9 @@ orchestrate:
       extra_vars:
         file:
         - variable_1.yml
+    environment_vars:
+      uname: 'Teflo_Teflo'
+      project: 'Teflo2.0'
 
 execute:
   - name: Test running command


### PR DESCRIPTION
* Added environment variables to be passed to the ansible module
* Modified schema to be able to provide env variables in the orchestrate and execute task blocks in the SDF