### PR TITLE
Allow IPv6 addresses SSH connection validation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         'apache-libcloud==2.2.0',
         "blaster>=0.3.0",
         'Click>=6.7',
+        'ipaddress',
         'Jinja2>=2.10',
         'pykwalify>=1.6.0',
         'python-cachetclient',


### PR DESCRIPTION
Currently SSH connections validations for IPv6 or hostnames which resolve to an IPv6 address do not work because we're using AF_INET address family which only covers IPv4 addressing. This patch proposes a check for the type of address and based on the result use AF_INET or AF_INET6 family.