### PR TITLE
CCITCARBON-422 Unit tests failing for centos-8 on github actions

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -26,6 +26,11 @@ jobs:
       - uses: actions/checkout@v2
       - run: cat /etc/os-release
 
+      # Fix for repositories because EOL of centos:8
+      - name: remove mirrorlist and point to vault.centos.org repo
+        run: |
+          cat /etc/os-release | grep -e "CentOS-8" || exit 0 && cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
       # Runs a single command using the runners shell
       - name: install required packages
         run: |


### PR DESCRIPTION
a small fix for the centos:8 container. 
it's just a workaround until we move to centos:stream and the customized UBI image

you can see here [1] that it finished successfully!

[1] https://github.com/shay6/teflo/pull/2