### PR TITLE
Revert "Upgrade Sphinx to be compatible with jinja2 v3.1.1 (#208)"

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,7 +6,7 @@ pycodestyle>=2.3.1
 pytest>=3.7.3
 #locking pytest-cov due to a regression with 2.8.0
 pytest-cov==2.7.1 
-Sphinx==4.5.0
+Sphinx==1.7.0
 sphinx-rtd-theme>=0.2.4
 tox>=2.7.0
 sphinx_automodapi


### PR DESCRIPTION
This reverts commit c9e42ea9a52dda1ffa86c86ab848f12887f0998e.