### PR TITLE
grab ipv4 address when node has multiple addresses

### DIFF
--- a/teflo/helpers.py
+++ b/teflo/helpers.py
@@ -822,6 +822,11 @@ def filter_host_name(name):
     return str(result[:20]).lower()
 
 
+def is_ipv4(address):
+    ip = ipaddress.ip_address(address)
+    return isinstance(ip, ipaddress.IPv4Address)
+
+
 def ssh_retry(obj):
     """
     Decorator to check SSH Connection before method execution.
@@ -854,14 +859,6 @@ def ssh_retry(obj):
                 raise HelpersError(
                     'ERROR: Unexpected error - Group %s not found in inventory file!' % kwargs['extra_vars']['hosts']
                 )
-
-        def is_ipv4(address):
-            ip = ipaddress.ip_address(address)
-
-            if isinstance(ip, ipaddress.IPv4Address):
-                return True
-            else:
-                return False
 
         def can_connect(group):
 

--- a/teflo/provisioners/ext/os_libcloud_plugin/openstack_libcloud_plugin.py
+++ b/teflo/provisioners/ext/os_libcloud_plugin/openstack_libcloud_plugin.py
@@ -36,7 +36,7 @@ from libcloud.compute.types import InvalidCredsError, Provider
 from teflo._compat import string_types
 from teflo.core import ProvisionerPlugin
 from teflo.exceptions import OpenstackProviderError
-from teflo.helpers import gen_random_str, filter_host_name, schema_validator
+from teflo.helpers import gen_random_str, filter_host_name, schema_validator, is_ipv4
 
 MAX_WAIT_TIME = 100
 MAX_ATTEMPTS = 3
@@ -515,7 +515,13 @@ class OpenstackLibCloudProvisionerPlugin(ProvisionerPlugin):
         # TODO: This might need more logic if we support a use case for more than one network specified
         if ip is None:
             node = self.driver.ex_get_node_details(node.id)
-            ip = node.private_ips[-1]
+            for pip in node.private_ips:
+                if is_ipv4(pip):
+                    ip = pip
+                    break
+            else:
+                ip = node.private_ips[-1]
+
         return ip, node.id
 
     def _delete(self, name):


### PR DESCRIPTION
Loop over the list of private ips on the node, grab the first available
ipv4 address. If no ipv4s are found, fallback to previous behavior of
popping last off the list.

resolves #221

Signed-off-by: Brady Pratt <bpratt@redhat.com>