### PR TITLE
CCITCARBON-356 More strict validation of schemas in teflo

### DIFF
--- a/teflo/provisioners/ext/bkr_client_plugin/beaker_client_plugin.py
+++ b/teflo/provisioners/ext/bkr_client_plugin/beaker_client_plugin.py
@@ -52,6 +52,8 @@ class BeakerClientProvisionerPlugin(ProvisionerPlugin):
     __plugin_name__ = "beaker-client"
     __schema_file_path__ = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                                         "schema.yml"))
+    __schema_ext_path__ = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                       "extensions.py"))
 
     def __init__(self, asset):
         """Constructor.
@@ -349,7 +351,8 @@ class BeakerClientProvisionerPlugin(ProvisionerPlugin):
         self.cancel_job(getattr(self.asset, 'asset_id'))
 
     def validate(self):
-        schema_validator(schema_data=self.build_profile(self.asset), schema_files=[self.__schema_file_path__])
+        schema_validator(schema_data=self.build_profile(self.asset), schema_files=[self.__schema_file_path__],
+                         schema_ext_files=[self.__schema_ext_path__])
 
     def get_job_status(self, xmldata):
         """Parse the beaker results.

--- a/teflo/provisioners/ext/bkr_client_plugin/extensions.py
+++ b/teflo/provisioners/ext/bkr_client_plugin/extensions.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Red Hat, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+    Pykwalify extensions module for beaker client plugin
+
+    Module containing custom validation functions used for beaker client schema checking.
+
+    :copyright: (c) 2021 Red Hat, Inc.
+    :license: GPLv3, see LICENSE for more details.
+"""
+
+import os
+
+
+def valid_file_exist(value, rule_obj, path):
+    """ Verify if the given file exist."""
+
+    if os.path.exists(value):
+        return True
+    else:
+        raise AssertionError(
+            '%s must be an existing file! Cannot find file: %s.' % (path.split('/')[-1], value)
+        )

--- a/teflo/provisioners/ext/bkr_client_plugin/schema.yml
+++ b/teflo/provisioners/ext/bkr_client_plugin/schema.yml
@@ -16,7 +16,7 @@ mapping:
   family:
     type: str
     required: False
-  whitboard:
+  whiteboard:
     type: str
     required: False
   kernel_options:
@@ -75,6 +75,7 @@ mapping:
   ssh_key:
     required: False
     type: str
+    func: valid_file_exist
   username:
     required: False
     type: str
@@ -92,6 +93,7 @@ mapping:
   kickstart:
     required: False
     type: str
+    func: valid_file_exist
   ksmeta:
     required: False
     type: seq


### PR DESCRIPTION
If the ssh_key file is not exist like below:
    `ssh_key: "keys/notRealFile"`

The stdout will look like this:
```
2022-05-23 17:10:57,883 INFO ** BLASTER BEGIN **
2022-05-23 17:10:57,911 INFO Validating <class 'teflo.resources.scenario.Scenario'> (beaker resource)
2022-05-23 17:10:57,913 INFO Validating <class 'teflo.resources.assets.Asset'> (beaker-node)
2022-05-23 17:10:57,914 INFO Beaker config already exists, skip creation.
2022-05-23 17:10:57,959 ERROR Failed to validate beaker-node
2022-05-23 17:10:57,961 ERROR A exception was raised while processing task: beaker-node method: run
Traceback (most recent call last):
  File "/home/shshevac/.virtualenvs/teflo/lib/python3.8/site-packages/blaster/blast.py", line 83, in run
    value = getattr(task_obj, method)()
  File "/home/shshevac/work/teflo/teflo/tasks/validate.py", line 54, in run
    self.resource.validate()
  File "/home/shshevac/work/teflo/teflo/resources/assets.py", line 540, in validate
    getattr(AssetProvisioner(self), 'validate')()
  File "/home/shshevac/work/teflo/teflo/provisioners/asset_provisioner.py", line 71, in validate
    self.plugin.validate()
  File "/home/shshevac/work/teflo/teflo/provisioners/ext/bkr_client_plugin/beaker_client_plugin.py", line 354, in validate
    schema_validator(schema_data=self.build_profile(self.asset), schema_files=[self.__schema_file_path__],
  File "/home/shshevac/work/teflo/teflo/helpers.py", line 384, in schema_validator
    c.validate(raise_exception=True)
  File "/home/shshevac/.virtualenvs/teflo/lib/python3.8/site-packages/pykwalify/core.py", line 183, in validate
    self._start_validate(self.source)
  File "/home/shshevac/.virtualenvs/teflo/lib/python3.8/site-packages/pykwalify/core.py", line 230, in _start_validate
    self._validate(value, root_rule, path, done)
  File "/home/shshevac/.virtualenvs/teflo/lib/python3.8/site-packages/pykwalify/core.py", line 264, in _validate
    self._validate_mapping(value, rule, path, done=None)
  File "/home/shshevac/.virtualenvs/teflo/lib/python3.8/site-packages/pykwalify/core.py", line 604, in _validate_mapping
    self._validate(v, r, u"{0}/{1}".format(path, k), done)
  File "/home/shshevac/.virtualenvs/teflo/lib/python3.8/site-packages/pykwalify/core.py", line 266, in _validate
    self._validate_scalar(value, rule, path, done=None)
  File "/home/shshevac/.virtualenvs/teflo/lib/python3.8/site-packages/pykwalify/core.py", line 659, in _validate_scalar
    self._handle_func(value, rule, path, done)
  File "/home/shshevac/.virtualenvs/teflo/lib/python3.8/site-packages/pykwalify/core.py", line 287, in _handle_func
    ret = method(value, rule, path)
  File "/home/shshevac/work/teflo/teflo/provisioners/ext/bkr_client_plugin/extensions.py", line 36, in valid_file_exist
    raise AssertionError(
AssertionError: ssh_key must be an existing file! Cannot find file: keys/notRealFile.
2022-05-23 17:10:57,963 INFO ** BLASTER COMPLETE **
2022-05-23 17:10:57,963 INFO     -> TOTAL DURATION: 0h:0m:0s
```