### PR TITLE
Improvements to downloading ansible roles/collections

### DIFF
--- a/docs/users/definitions/orchestrate.rst
+++ b/docs/users/definitions/orchestrate.rst
@@ -583,29 +583,16 @@ Use the **file** key to pass a variable file to the playbook. This file needs to
                 playbook:
                 - name: ansible/template_host_test_playbook_tasks.yml
 
+Ansible Galaxy
+~~~~~~~~~~~~~~
 
-
-
-Ansible Galaxy Options
-~~~~~~~~~~~~~~~~~~~~~~
-
-These are additional options provided to the ansible orchestrator regarding the ansible roles and collections
-
-Retry
-+++++
-
-To make sure ansible roles and collections are downloaded correctly, 'retry' ansible galaxy option is used
-
-.. code-block:: yaml
-
-    ---
-    - name: ansible/setup-vnc.yml
-      description: "setup a vnc server on test clients"
-      orchestrator: ansible
-      hosts: vnc
-      ansible_galaxy_options:
-        role_file: roles.yml
-        retry: True
+Before teflo initiates the `ansible-playbook` command, it will attempt to download any
+roles or collections based on what is configured within the `ansible_galaxy_options`
+for the given task. Teflo downloads these dependencies using the `ansible-galaxy`
+command. In the event the command fails for any reason, teflo will retry the download.
+A maximum of `2` attempts will be made with a `30` second delay between attempts. Teflo
+will stop immediately when its unable to download the roles. Reducing potential playbook
+failures at a later point.
 
 Examples
 --------

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         'python-cachetclient',
         'ruamel.yaml>=0.15.64',
         'paramiko>=2.4.2',
+        'retry2>=0.9.4',
         'ssh-python==0.9.0',
         'requests>=2.20.1',
         'urllib3>=1.26',

--- a/teflo/ansible_helpers.py
+++ b/teflo/ansible_helpers.py
@@ -47,8 +47,9 @@ from .exceptions import AnsibleServiceError
 from ansible.parsing.vault import VaultSecret
 from .exceptions import AnsibleVaultError
 from ._compat import RawConfigParser, VaultLib, ansible_ver, is_py2
-import configparser
+from .constants import ANSIBLE_GALAXY_INSTALL_ATTEMPTS, ANSIBLE_GALAXY_INSTALL_DELAY
 import glob
+from retry import retry
 
 LOG = getLogger(__name__)
 
@@ -221,7 +222,6 @@ class AnsibleController(object):
 
 
 class AnsibleService(object):
-
     user_run_vals = ["become", "become_method", "become_user", "remote_user",
                      "connection", "forks", "tags", 'skip_tags', 'vault-password-file']
 
@@ -454,77 +454,67 @@ class AnsibleService(object):
         with open(playbook, 'w') as f:
             yaml.dump(yaml.load(playbook_str), f)
 
+    @retry(AnsibleServiceError, tries=ANSIBLE_GALAXY_INSTALL_ATTEMPTS, delay=ANSIBLE_GALAXY_INSTALL_DELAY)
     def download_roles(self):
-        """Download ansible roles and collections defined for the given action."""
-        flag = 0
+        """Download ansible dependencies (roles or collections).
 
+        Retries will be attempted in the event any error occurs
+        while trying to download dependencies.
+        """
         if self.galaxy_options is None:
             return
 
-        if 'role_file' in self.galaxy_options:
+        flag = 0
+
+        if "role_file" in self.galaxy_options:
+            requirements_file = os.path.join(self.config["WORKSPACE"], self.galaxy_options["role_file"])
+            requirements_file_content = file_mgmt("r", requirements_file)
             flag += 1
 
-            f = os.path.join(self.config['WORKSPACE'],
-                             self.galaxy_options['role_file'])
-            file_output = file_mgmt('r', f)
-            if isinstance(file_output, list):
-                cmd = 'ansible-galaxy role install -r %s' % f
-                self.logger.info('Installing roles using req. file: %s' % f)
-                results = exec_local_cmd_pipe(cmd, self.logger)
-                if results[0] != 0:
-                    raise AnsibleServiceError(
-                        'A problem occurred while installing roles using req. file'
-                        ' %s' % f)
-                self.logger.info('Roles installed successfully from: %s!' % f)
-            elif isinstance(file_output, dict):
-                if 'roles' in file_output:
-                    cmd = 'ansible-galaxy role install -r %s' % f
-                    self.logger.info('Installing roles using req. file: %s' % f)
-                    results = exec_local_cmd_pipe(cmd, self.logger)
-                    if results[0] != 0:
-                        raise AnsibleServiceError(
-                            'A problem occurred while installing roles using req. file'
-                            ' %s' % f)
-                    self.logger.info('Roles installed successfully from: %s!' % f)
-                if 'collections' in file_output:
-                    cmd = 'ansible-galaxy collection install -r %s' % f
-                    self.logger.info('Installing collections using req. file: %s' % f)
-                    results = exec_local_cmd_pipe(cmd, self.logger)
-                    if results[0] != 0:
-                        raise AnsibleServiceError(
-                            'A problem occurred while installing collections using req. file'
-                            ' %s' % f)
-                    self.logger.info('Collections installed successfully from: %s!' % f)
+            dependencies = {
+                "role": False,
+                "collection": False
+            }
 
-        if 'roles' in self.galaxy_options:
+            if isinstance(requirements_file_content, list):
+                dependencies["role"] = True
+            elif isinstance(requirements_file_content, dict):
+                dependencies["role"] = "roles" in requirements_file_content
+                dependencies["collection"] = "collections" in requirements_file_content
+
+            for key, value in dependencies.items():
+                if not key:
+                    continue
+
+                self.logger.info(f"Install {key}s using requirements file {requirements_file}")
+                results = exec_local_cmd_pipe(f"ansible-galaxy {key} install -r {requirements_file}", self.logger)
+                if results[0] != 0:
+                    message = f"Failed to install {key}s from requirements file {requirements_file}. " \
+                              f"Error: {results[1]}"
+                    self.logger.error(message)
+                    raise AnsibleServiceError(message)
+                self.logger.info(f"{key.title()}s installed from requirements file {requirements_file}!")
+
+        dependencies = {
+            "role": self.galaxy_options.get("roles", {}),
+            "collection": self.galaxy_options.get("collections", {})
+        }
+
+        for key, value in dependencies.items():
+            if not value:
+                continue
+
             if flag >= 1:
-                self.logger.warning('FYI roles were already installed using a'
-                                    ' requirements file. Problems may occur.')
+                self.logger.warning(f"Attention: {key}s were already installed using a requirements "
+                                    f"file. Potential problems may occur.")
 
-            for item in self.galaxy_options['roles']:
-                cmd = 'ansible-galaxy install %s' % item
-                results = exec_local_cmd_pipe(cmd, self.logger)
-
+            for item in value:
+                results = exec_local_cmd_pipe(f"ansible-galaxy {key} install {item}", self.logger)
                 if results[0] != 0:
-                    raise AnsibleServiceError(
-                        'A problem occurred while installing role: %s' % item
-                    )
-                self.logger.info('Role: %s successfully installed!' % item)
-
-        if 'collections' in self.galaxy_options:
-            if flag >= 1:
-                self.logger.warning('FYI collections were already installed using a'
-                                    ' requirements file. Problems may occur.')
-
-            for item in self.galaxy_options['collections']:
-                cmd = 'ansible-galaxy collection install %s' % item
-                results = exec_local_cmd_pipe(cmd, self.logger)
-
-                if results[0] != 0:
-                    raise AnsibleServiceError(
-                        'A problem occurred while installing collection: %s' % item
-                    )
-                self.logger.info('Collection: %s successfully installed!' % item)
+                    message = f"Failed to install {key}. Error: {results[1]}"
+                    self.logger.error(message)
+                    raise AnsibleServiceError(message)
+                self.logger.info(f"{key.title()} '{item}' installed!")
 
     def get_default_config(self, key=None):
         """getting the default configuration defined by ansible.cfg

--- a/teflo/constants.py
+++ b/teflo/constants.py
@@ -180,3 +180,7 @@ LOGGING_CONFIG = {
                        'propagate': False},
     }
 }
+
+# Default retries for installing ansible dependencies
+ANSIBLE_GALAXY_INSTALL_DELAY = 30
+ANSIBLE_GALAXY_INSTALL_ATTEMPTS = 2

--- a/teflo/orchestrators/ext/ansible_orchestrator_plugin/ansible_orchestrator_plugin.py
+++ b/teflo/orchestrators/ext/ansible_orchestrator_plugin/ansible_orchestrator_plugin.py
@@ -117,14 +117,7 @@ class AnsibleOrchestratorPlugin(OrchestratorPlugin):
                 self.logger.debug('Found Action resource playbook %s' % self.playbook.get('name'))
             elif True:
                 # DOWNLOAD COLLECTION AND CHECK IF STRING IS VALID FQCR.
-                try:
-                    self.ans_service.download_roles()
-                except (TefloOrchestratorError, AnsibleServiceError):
-                    if 'retry' in self.galaxy_options and self.galaxy_options['retry']:
-                        self.logger.Info("Download failed.  Sleeping 5 seconds and \
-                                          trying again")
-                        time.sleep(5)
-                        self.ans_service.download_roles()
+                self.ans_service.download_roles()
                 coll_playbook_name = self.ans_service.get_default_config(key="COLLECTIONS_PATHS")
                 if os.path.exists(coll_playbook_name[0]):
                     new_path = self.ans_service.get_playbook_path(coll_path=coll_playbook_name[0],
@@ -202,18 +195,11 @@ class AnsibleOrchestratorPlugin(OrchestratorPlugin):
             # if more than one action types are declared then the first action_type found will be executed
             if getattr(self, item):
                 flag += 1
-                # Download ansible roles (if applicable)
                 if flag == 1:
                     try:
+                        # Download ansible roles/collections
                         self.ans_service.download_roles()
-                    except (TefloOrchestratorError, AnsibleServiceError):
-                        if 'retry' in self.galaxy_options and self.galaxy_options['retry']:
-                            self.logger.Info("Download failed.  Sleeping 5 seconds and \
-                                              trying again")
-                            time.sleep(5)
-                            self.ans_service.download_roles()
 
-                    try:
                         getattr(self, '__%s__' % item)()
                         # If every script/playbook/shell command within the each orchestrate has passed,
                         # mark that task as successful

--- a/teflo/utils/resource_checker.py
+++ b/teflo/utils/resource_checker.py
@@ -82,14 +82,7 @@ class ResourceChecker(object):
                 self.ans_service.galaxy_options = item.get('ansible_galaxy_options', None)
 
                 # downloading ansible_roles
-                try:
-                    self.ans_service.download_roles()
-                except (TefloError, AnsibleServiceError):
-                    if 'retry' in self.ans_service.galaxy_options and self.ans_service.galaxy_options['retry']:
-                        LOG.info("Download failed.  Sleeping 5 seconds and \
-                                          trying again")
-                        time.sleep(5)
-                        self.ans_service.download_roles()
+                self.ans_service.download_roles()
 
                 error_msg = ''
                 try:

--- a/tests/functional/test_ansible_helpers.py
+++ b/tests/functional/test_ansible_helpers.py
@@ -28,6 +28,8 @@
 import pytest
 import mock
 import os
+
+import teflo.helpers
 from teflo.ansible_helpers import AnsibleService, AnsibleController
 from teflo.exceptions import AnsibleServiceError
 
@@ -166,4 +168,32 @@ class TestAnsibleService(object):
         group = ansible_service.create_inv_group()
         assert group == 'host_0, host_1'
 
+    @staticmethod
+    def test_download_roles_empty(ansible_service):
+        assert ansible_service.download_roles() is None
 
+    @staticmethod
+    @mock.patch("teflo.ansible_helpers.file_mgmt")
+    @mock.patch("teflo.ansible_helpers.exec_local_cmd_pipe")
+    def test_download_roles_valid(exec_local_cmd_pipe, file_mgmt, ansible_service):
+        exec_local_cmd_pipe.return_value = mock.Mock()
+        exec_local_cmd_pipe.return_value = 0, "pass"
+        file_mgmt.return_value = mock.Mock()
+        file_mgmt.return_value = {
+            "roles": ["role-123"],
+            "collections": ["collection-123"]
+        }
+
+        ansible_service.galaxy_options = {
+            "role_file": "requirements.yml",
+            "roles": ["role-123"],
+            "collections": ["collection-123"]
+        }
+        assert ansible_service.download_roles() is None
+
+    @staticmethod
+    def test_download_roles_invalid(ansible_service):
+        with pytest.raises(AnsibleServiceError):
+            ansible_service.download_roles = mock.Mock()
+            ansible_service.download_roles.side_effect = AnsibleServiceError("Error")
+            ansible_service.download_roles()


### PR DESCRIPTION
# Change

This PR enables automatic retries when attempting to download ansible dependencies (roles or collections). Today, this is not enabled by default. The user needs to pass `retry` in their ansible options in order to do one retry attempt. Even if teflo fails to download roles, teflo still continues on. Resulting in playbooks failing to run at a later point due to missing dependencies (e.g. roles or collections).

Below is a list of changes provided by this PR.

Includes:
1. Include retry attempts by default. Previously this was only enabled
   when passing the `retry` flag with your ansible options. If it
   failed, it would attempt the retry one more time.
2. Do not allow teflo to carry on when ansible requirements were not
   downloaded successfully. This removes the potential playbook errors
   at a later point, when its unable to locate a collection or role.
3. Update/add new error messages to help make it easier for the user to
   understand why it failed to download ansible requirements.
4. Reduce code duplication for download_roles method.

# Verification

1. Invalid roles or collections in requirements file.

```
(venv) [rywillia@t14s mock_openshift]$ teflo run -t validate -s $TEFLO_SDF
--------------------------------------------------
Teflo Framework v2.2.6
Copyright (C) 2022, Red Hat, Inc.
--------------------------------------------------
2022-08-29 13:52:05,614 WARNING Scenario workspace was not set, therefore the workspace is automatically assigned to the current working directory. You may experience problems if files needed by teflo do not exists in the scenario workspace.
2022-08-29 13:52:05,776 INFO 

2022-08-29 13:52:05,776 INFO                                TEFLO RUN (START)                               
2022-08-29 13:52:05,776 INFO -------------------------------------------------------------------------------
2022-08-29 13:52:05,776 INFO  * Data Folder           : ./.teflo/446uodc5za
2022-08-29 13:52:05,777 INFO  * Workspace             : /home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/mock_openshift
2022-08-29 13:52:05,777 INFO  * Log Level             : info
2022-08-29 13:52:05,777 INFO  * Tasks                 : ['validate']
2022-08-29 13:52:05,777 INFO  * Iterate Method        : by_level
2022-08-29 13:52:05,778 INFO  * Scenario              : resource_check
2022-08-29 13:52:05,778 INFO  * Scenario              : provision_base
2022-08-29 13:52:05,778 INFO  * Scenario              : orchestrate_base
2022-08-29 13:52:05,778 INFO  * Scenario              : orchestrate
2022-08-29 13:52:05,779 INFO  * Scenario              : orchestrate_install_openshift
2022-08-29 13:52:05,779 INFO  * Scenario              : execute
2022-08-29 13:52:05,779 INFO  * Scenario              : Layered product OpenShift unit test scenario
2022-08-29 13:52:05,779 INFO -------------------------------------------------------------------------------

2022-08-29 13:52:05,780 INFO Validating against all scenarios!
2022-08-29 13:52:05,780 INFO ..................................................
2022-08-29 13:52:05,780 INFO ..................................................
2022-08-29 13:52:05,781 INFO 'resource_check' is validated from the scenario file: resource_check.yml
2022-08-29 13:52:05,781 INFO ..................................................
2022-08-29 13:52:05,781 INFO ..................................................
2022-08-29 13:52:05,781 INFO 'resource_check' is running from the scenario file: resource_check.yml
2022-08-29 13:52:05,782 INFO ..................................................
2022-08-29 13:52:05,783 INFO  * Task    : validate
2022-08-29 13:52:05,784 INFO ..................................................
2022-08-29 13:52:05,784 INFO Starting tasks on pipeline: validate
2022-08-29 13:52:05,785 INFO --> Blaster v0.5.0 <--
2022-08-29 13:52:05,785 INFO Task Execution: Sequential
2022-08-29 13:52:05,785 INFO Tasks:
2022-08-29 13:52:05,786 INFO 1. Task     : resource_check
                                Class    : <class 'teflo.tasks.validate.ValidateTask'>
                                Methods  : ['run']
2022-08-29 13:52:05,786 INFO ** BLASTER BEGIN **
2022-08-29 13:52:05,787 INFO Validating <class 'teflo.resources.scenario.Scenario'> (resource_check)
2022-08-29 13:52:05,788 INFO Running validation using user provided playbook/scripts
2022-08-29 13:52:05,790 INFO Install roles using requirements file /home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/mock_openshift/ansible/requirements.yml
2022-08-29 13:52:06,173 INFO Skipping install, no requirements found
2022-08-29 13:52:06,231 INFO Roles installed from requirements file /home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/mock_openshift/ansible/requirements.yml!
2022-08-29 13:52:06,231 INFO Install collections using requirements file /home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/mock_openshift/ansible/requirements.yml
2022-08-29 13:52:06,650 INFO Starting galaxy collection install process
2022-08-29 13:52:06,653 INFO Process install dependency map
2022-08-29 13:52:07,183 ERROR Failed to install collections from requirements file /home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/mock_openshift/ansible/requirements.yml. Error: Cloning into '/home/rywillia/.ansible/tmp/ansible-local-167590bg4yig52/tmp98s5sb5r/ansible_collectionhzjipz2b'...
error: pathspec 'main22' did not match any file(s) known to git
ERROR! Failed to switch a cloned Git repo `https://gitlab.cee.redhat.com/PIT/ansible_collection.git` to the requested revision `main22`.

2022-08-29 13:52:37,216 INFO Install roles using requirements file /home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/mock_openshift/ansible/requirements.yml
2022-08-29 13:52:37,659 INFO Skipping install, no requirements found
2022-08-29 13:52:37,719 INFO Roles installed from requirements file /home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/mock_openshift/ansible/requirements.yml!
2022-08-29 13:52:37,719 INFO Install collections using requirements file /home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/mock_openshift/ansible/requirements.yml
2022-08-29 13:52:38,111 INFO Starting galaxy collection install process
2022-08-29 13:52:38,114 INFO Process install dependency map
2022-08-29 13:52:38,715 ERROR Failed to install collections from requirements file /home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/mock_openshift/ansible/requirements.yml. Error: Cloning into '/home/rywillia/.ansible/tmp/ansible-local-167896sijrrqhj/tmpthprngdm/ansible_collection0bgq7d0l'...
error: pathspec 'main22' did not match any file(s) known to git
ERROR! Failed to switch a cloned Git repo `https://gitlab.cee.redhat.com/PIT/ansible_collection.git` to the requested revision `main22`.

2022-08-29 13:52:38,716 ERROR Failed to validate resource_check
2022-08-29 13:52:38,717 ERROR A exception was raised while processing task: resource_check method: run
Traceback (most recent call last):
  File "/home/rywillia/work/ryankwilliams/teflo/teflo/utils/resource_checker.py", line 86, in __check_custom_resource
    self.ans_service.download_roles()
  File "/home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/lib64/python3.10/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/lib64/python3.10/site-packages/retry/api.py", line 90, in retry_decorator
    return __retry_internal(partial(f, *args, **kwargs), exceptions, tries, delay, max_delay, backoff, jitter,
  File "/home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/lib64/python3.10/site-packages/retry/api.py", line 35, in __retry_internal
    return f()
  File "/home/rywillia/work/ryankwilliams/teflo/teflo/ansible_helpers.py", line 495, in download_roles
    raise AnsibleServiceError(message)
teflo.exceptions.AnsibleServiceError: Failed to install collections from requirements file /home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/mock_openshift/ansible/requirements.yml. Error: Cloning into '/home/rywillia/.ansible/tmp/ansible-local-167896sijrrqhj/tmpthprngdm/ansible_collection0bgq7d0l'...
error: pathspec 'main22' did not match any file(s) known to git
ERROR! Failed to switch a cloned Git repo `https://gitlab.cee.redhat.com/PIT/ansible_collection.git` to the requested revision `main22`.


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/lib64/python3.10/site-packages/blaster/blast.py", line 83, in run
    value = getattr(task_obj, method)()
  File "/home/rywillia/work/ryankwilliams/teflo/teflo/tasks/validate.py", line 54, in run
    self.resource.validate()
  File "/home/rywillia/work/ryankwilliams/teflo/teflo/resources/scenario.py", line 693, in validate
    rs.validate_resources()
  File "/home/rywillia/work/ryankwilliams/teflo/teflo/utils/resource_checker.py", line 67, in validate_resources
    self.__check_custom_resource()
  File "/home/rywillia/work/ryankwilliams/teflo/teflo/utils/resource_checker.py", line 88, in __check_custom_resource
    raise TefloError("Failed to download ansible roles/collections")
teflo.exceptions.TefloError: Failed to download ansible roles/collections
2022-08-29 13:52:39,719 INFO ** BLASTER COMPLETE **
2022-08-29 13:52:39,720 INFO     -> TOTAL DURATION: 0h:0m:33s
2022-08-29 13:52:39,720 ERROR One or more tasks got a status of non zero.
Traceback (most recent call last):
  File "/home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/bin/teflo", line 33, in <module>
    sys.exit(load_entry_point('teflo', 'console_scripts', 'teflo')())
  File "/home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/lib64/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/lib64/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/lib64/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/lib64/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/lib64/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/lib64/python3.10/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/rywillia/work/ryankwilliams/teflo/teflo/cli.py", line 298, in run
    cbn.run(tasklist=task)
  File "/home/rywillia/work/ryankwilliams/teflo/teflo/teflo.py", line 426, in run
    self.run_all_helper(tasklist, final_passed_tasks, final_failed_tasks, status)
  File "/home/rywillia/work/ryankwilliams/teflo/teflo/teflo.py", line 383, in run_all_helper
    self.run_all_validate_helper(final_passed_tasks, final_failed_tasks, status)
  File "/home/rywillia/work/ryankwilliams/teflo/teflo/teflo.py", line 365, in run_all_validate_helper
    self.run_helper(sc=sc, tasklist=["validate"])
  File "/home/rywillia/work/ryankwilliams/teflo/teflo/teflo.py", line 614, in run_helper
    exit_on_status()
  File "/home/rywillia/work/ryankwilliams/teflo/teflo/teflo.py", line 611, in exit_on_status
    raise TefloScenarioFailure(
teflo.exceptions.TefloScenarioFailure: Scenario `resource_check` failed during the Teflo run
```

2. Valid requirements file

```
(venv) [rywillia@t14s mock_openshift]$ teflo run -t validate -s $TEFLO_SDF
--------------------------------------------------
Teflo Framework v2.2.6
Copyright (C) 2022, Red Hat, Inc.
--------------------------------------------------
2022-08-29 14:02:05,375 WARNING Scenario workspace was not set, therefore the workspace is automatically assigned to the current working directory. You may experience problems if files needed by teflo do not exists in the scenario workspace.
2022-08-29 14:02:05,612 INFO 

2022-08-29 14:02:05,612 INFO                                TEFLO RUN (START)                               
2022-08-29 14:02:05,612 INFO -------------------------------------------------------------------------------
2022-08-29 14:02:05,613 INFO  * Data Folder           : ./.teflo/c1d09dj2a1
2022-08-29 14:02:05,613 INFO  * Workspace             : /home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/mock_openshift
2022-08-29 14:02:05,613 INFO  * Log Level             : info
2022-08-29 14:02:05,613 INFO  * Tasks                 : ['validate']
2022-08-29 14:02:05,614 INFO  * Iterate Method        : by_level
2022-08-29 14:02:05,614 INFO  * Scenario              : resource_check
2022-08-29 14:02:05,615 INFO  * Scenario              : provision_base
2022-08-29 14:02:05,615 INFO  * Scenario              : orchestrate_base
2022-08-29 14:02:05,615 INFO  * Scenario              : orchestrate
2022-08-29 14:02:05,616 INFO  * Scenario              : orchestrate_install_openshift
2022-08-29 14:02:05,616 INFO  * Scenario              : execute
2022-08-29 14:02:05,616 INFO  * Scenario              : Layered product OpenShift unit test scenario
2022-08-29 14:02:05,617 INFO -------------------------------------------------------------------------------

2022-08-29 14:02:05,617 INFO Validating against all scenarios!
2022-08-29 14:02:05,618 INFO ..................................................
2022-08-29 14:02:05,618 INFO ..................................................
2022-08-29 14:02:05,618 INFO 'resource_check' is validated from the scenario file: resource_check.yml
2022-08-29 14:02:05,619 INFO ..................................................
2022-08-29 14:02:05,619 INFO ..................................................
2022-08-29 14:02:05,619 INFO 'resource_check' is running from the scenario file: resource_check.yml
2022-08-29 14:02:05,620 INFO ..................................................
2022-08-29 14:02:05,621 INFO  * Task    : validate
2022-08-29 14:02:05,622 INFO ..................................................
2022-08-29 14:02:05,623 INFO Starting tasks on pipeline: validate
2022-08-29 14:02:05,623 INFO --> Blaster v0.5.0 <--
2022-08-29 14:02:05,624 INFO Task Execution: Sequential
2022-08-29 14:02:05,624 INFO Tasks:
2022-08-29 14:02:05,625 INFO 1. Task     : resource_check
                                Class    : <class 'teflo.tasks.validate.ValidateTask'>
                                Methods  : ['run']
2022-08-29 14:02:05,625 INFO ** BLASTER BEGIN **
2022-08-29 14:02:05,626 INFO Validating <class 'teflo.resources.scenario.Scenario'> (resource_check)
2022-08-29 14:02:05,627 INFO Running validation using user provided playbook/scripts
2022-08-29 14:02:05,629 INFO Install roles using requirements file /home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/mock_openshift/ansible/requirements.yml
2022-08-29 14:02:06,168 INFO Skipping install, no requirements found
2022-08-29 14:02:06,253 INFO Roles installed from requirements file /home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/mock_openshift/ansible/requirements.yml!
2022-08-29 14:02:06,254 INFO Install collections using requirements file /home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/mock_openshift/ansible/requirements.yml
2022-08-29 14:02:06,802 INFO Starting galaxy collection install process
2022-08-29 14:02:06,806 INFO Process install dependency map
2022-08-29 14:02:07,399 INFO Your branch is up to date with 'origin/main'.
2022-08-29 14:02:07,401 INFO Starting collection install process
2022-08-29 14:02:07,401 INFO Installing 'interop.ansible:1.0.0' to '/home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/mock_openshift/ansible/ansible_collections/interop/ansible'
2022-08-29 14:02:07,425 INFO Created collection for interop.ansible:1.0.0 at /home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/mock_openshift/ansible/ansible_collections/interop/ansible
2022-08-29 14:02:07,426 INFO interop.ansible:1.0.0 was installed successfully
2022-08-29 14:02:07,519 INFO Collections installed from requirements file /home/rywillia/work/rywillia/pit/scenarios/mock_openshift/venv/mock_openshift/ansible/requirements.yml!
2022-08-29 14:02:07,519 INFO Ansible options used: {}
2022-08-29 14:02:07,520 INFO Executing playbook : ansible/relocate_files.yml
[WARNING]: Found both group and host with same name: localhost
2022-08-29 14:02:08,096 INFO 
2022-08-29 14:02:08,097 INFO PLAY [Relocate Interop QE OpenShift automation files for easier scenario access] ***
2022-08-29 14:02:08,110 INFO 
2022-08-29 14:02:08,111 INFO TASK [Gathering Facts] *********************************************************
2022-08-29 14:02:11,939 INFO ok: [localhost]
2022-08-29 14:02:11,964 INFO 
2022-08-29 14:02:11,964 INFO TASK [Copy OpenShift automation files to scenarios ansible directory] **********
2022-08-29 14:02:24,810 INFO ok: [localhost]
2022-08-29 14:02:24,836 INFO 
2022-08-29 14:02:24,836 INFO PLAY RECAP *********************************************************************
2022-08-29 14:02:24,836 INFO localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
2022-08-29 14:02:24,836 INFO 
2022-08-29 14:02:24,961 INFO Successfully completed resource_check validation for playbook/script: ansible/relocate_files.yml
2022-08-29 14:02:25,010 INFO ** BLASTER COMPLETE **
2022-08-29 14:02:25,011 INFO     -> TOTAL DURATION: 0h:0m:19s
2022-08-29 14:02:25,011 INFO ..................................................
2022-08-29 14:02:25,014 INFO ..................................................
2022-08-29 14:02:25,016 INFO 'provision_base' is validated from the scenario file: provision_base.yml
2022-08-29 14:02:25,016 INFO ..................................................
2022-08-29 14:02:25,017 INFO ..................................................
2022-08-29 14:02:25,018 INFO 'provision_base' is running from the scenario file: provision_base.yml
2022-08-29 14:02:25,019 INFO ..................................................
2022-08-29 14:02:25,024 INFO  * Task    : validate
2022-08-29 14:02:25,024 INFO ..................................................
2022-08-29 14:02:25,025 INFO Starting tasks on pipeline: validate
2022-08-29 14:02:25,025 INFO --> Blaster v0.5.0 <--
2022-08-29 14:02:25,026 INFO Task Execution: Sequential
2022-08-29 14:02:25,027 INFO Tasks:
2022-08-29 14:02:25,027 INFO 1. Task     : provision_base
                                Class    : <class 'teflo.tasks.validate.ValidateTask'>
                                Methods  : ['run']
2022-08-29 14:02:25,028 INFO 2. Task     : ocp_driver_rywillia
                                Class    : <class 'teflo.tasks.validate.ValidateTask'>
                                Methods  : ['run']
2022-08-29 14:02:25,028 INFO ** BLASTER BEGIN **
2022-08-29 14:02:25,030 INFO Validating <class 'teflo.resources.scenario.Scenario'> (provision_base)
2022-08-29 14:02:25,086 INFO Validating <class 'teflo.resources.assets.Asset'> (ocp_driver_rywillia)
2022-08-29 14:02:25,117 INFO successfully validated scenario Asset against the schema!
2022-08-29 14:02:25,118 INFO ** BLASTER COMPLETE **
2022-08-29 14:02:25,119 INFO     -> TOTAL DURATION: 0h:0m:0s
2022-08-29 14:02:25,120 INFO ..................................................
2022-08-29 14:02:25,124 INFO ..................................................
2022-08-29 14:02:25,125 INFO 'orchestrate_base' is validated from the scenario file: orchestrate_base.yml
2022-08-29 14:02:25,125 INFO ..................................................
2022-08-29 14:02:25,126 INFO ..................................................
2022-08-29 14:02:25,127 INFO 'orchestrate_base' is running from the scenario file: orchestrate_base.yml
2022-08-29 14:02:25,128 INFO ..................................................
2022-08-29 14:02:25,131 INFO  * Task    : validate
2022-08-29 14:02:25,133 INFO ..................................................
2022-08-29 14:02:25,133 INFO Starting tasks on pipeline: validate
2022-08-29 14:02:25,134 INFO --> Blaster v0.5.0 <--
2022-08-29 14:02:25,135 INFO Task Execution: Sequential
2022-08-29 14:02:25,136 INFO Tasks:
2022-08-29 14:02:25,136 INFO 1. Task     : orchestrate_base
                                Class    : <class 'teflo.tasks.validate.ValidateTask'>
                                Methods  : ['run']
2022-08-29 14:02:25,137 INFO 2. Task     : Move interop-qe-openshift files to scenario's ansible directory
                                Class    : <class 'teflo.tasks.validate.ValidateTask'>
                                Methods  : ['run']
2022-08-29 14:02:25,138 INFO 3. Task     : Configure OpenShift test driver
                                Class    : <class 'teflo.tasks.validate.ValidateTask'>
                                Methods  : ['run']
2022-08-29 14:02:25,139 INFO 4. Task     : Download OpenShift client 'oc'
                                Class    : <class 'teflo.tasks.validate.ValidateTask'>
                                Methods  : ['run']
2022-08-29 14:02:25,139 INFO 5. Task     : Configure environment for administrator access to OCP cluster
                                Class    : <class 'teflo.tasks.validate.ValidateTask'>
                                Methods  : ['run']
2022-08-29 14:02:25,140 INFO ** BLASTER BEGIN **
2022-08-29 14:02:25,141 INFO Validating <class 'teflo.resources.scenario.Scenario'> (orchestrate_base)
2022-08-29 14:02:25,216 INFO Validating <class 'teflo.resources.actions.Action'> (Move interop-qe-openshift files to scenario's ansible directory)
2022-08-29 14:02:25,246 INFO successfully validated scenario Action Move interop-qe-openshift files to scenario's ansible directory against the schema!
2022-08-29 14:02:25,248 INFO Validating <class 'teflo.resources.actions.Action'> (Configure OpenShift test driver)
2022-08-29 14:02:25,270 INFO successfully validated scenario Action Configure OpenShift test driver against the schema!
2022-08-29 14:02:25,272 INFO Validating <class 'teflo.resources.actions.Action'> (Download OpenShift client 'oc')
2022-08-29 14:02:25,293 INFO successfully validated scenario Action Download OpenShift client 'oc' against the schema!
2022-08-29 14:02:25,294 INFO Validating <class 'teflo.resources.actions.Action'> (Configure environment for administrator access to OCP cluster)
2022-08-29 14:02:25,312 INFO successfully validated scenario Action Configure environment for administrator access to OCP cluster against the schema!
2022-08-29 14:02:25,313 INFO ** BLASTER COMPLETE **
2022-08-29 14:02:25,314 INFO     -> TOTAL DURATION: 0h:0m:0s
2022-08-29 14:02:25,316 INFO ..................................................
2022-08-29 14:02:25,319 INFO ..................................................
2022-08-29 14:02:25,321 INFO 'orchestrate' is validated from the scenario file: orchestrate.yml
2022-08-29 14:02:25,321 INFO ..................................................
2022-08-29 14:02:25,322 INFO ..................................................
2022-08-29 14:02:25,322 INFO 'orchestrate' is running from the scenario file: orchestrate.yml
2022-08-29 14:02:25,323 INFO ..................................................
2022-08-29 14:02:25,325 INFO  * Task    : validate
2022-08-29 14:02:25,326 INFO ..................................................
2022-08-29 14:02:25,326 INFO Starting tasks on pipeline: validate
2022-08-29 14:02:25,327 INFO --> Blaster v0.5.0 <--
2022-08-29 14:02:25,328 INFO Task Execution: Sequential
2022-08-29 14:02:25,329 INFO Tasks:
2022-08-29 14:02:25,330 INFO 1. Task     : orchestrate
                                Class    : <class 'teflo.tasks.validate.ValidateTask'>
                                Methods  : ['run']
2022-08-29 14:02:25,331 INFO 2. Task     : Setup test driver for pytests
                                Class    : <class 'teflo.tasks.validate.ValidateTask'>
                                Methods  : ['run']
2022-08-29 14:02:25,331 INFO ** BLASTER BEGIN **
2022-08-29 14:02:25,333 INFO Validating <class 'teflo.resources.scenario.Scenario'> (orchestrate)
2022-08-29 14:02:25,389 INFO Validating <class 'teflo.resources.actions.Action'> (Setup test driver for pytests)
2022-08-29 14:02:25,408 INFO successfully validated scenario Action Setup test driver for pytests against the schema!
2022-08-29 14:02:25,409 INFO ** BLASTER COMPLETE **
2022-08-29 14:02:25,410 INFO     -> TOTAL DURATION: 0h:0m:0s
2022-08-29 14:02:25,411 INFO ..................................................
2022-08-29 14:02:25,413 INFO ..................................................
2022-08-29 14:02:25,414 INFO 'orchestrate_install_openshift' is validated from the scenario file: orchestrate_install_openshift_openstack.yml
2022-08-29 14:02:25,414 INFO ..................................................
2022-08-29 14:02:25,414 INFO ..................................................
2022-08-29 14:02:25,415 INFO 'orchestrate_install_openshift' is running from the scenario file: orchestrate_install_openshift_openstack.yml
2022-08-29 14:02:25,416 INFO ..................................................
2022-08-29 14:02:25,420 INFO  * Task    : validate
2022-08-29 14:02:25,422 INFO ..................................................
2022-08-29 14:02:25,422 INFO Starting tasks on pipeline: validate
2022-08-29 14:02:25,423 INFO --> Blaster v0.5.0 <--
2022-08-29 14:02:25,423 INFO Task Execution: Sequential
2022-08-29 14:02:25,424 INFO Tasks:
2022-08-29 14:02:25,424 INFO 1. Task     : orchestrate_install_openshift
                                Class    : <class 'teflo.tasks.validate.ValidateTask'>
                                Methods  : ['run']
2022-08-29 14:02:25,424 INFO 2. Task     : Create OpenShift cluster
                                Class    : <class 'teflo.tasks.validate.ValidateTask'>
                                Methods  : ['run']
2022-08-29 14:02:25,425 INFO ** BLASTER BEGIN **
2022-08-29 14:02:25,426 INFO Validating <class 'teflo.resources.scenario.Scenario'> (orchestrate_install_openshift)
2022-08-29 14:02:25,486 INFO Validating <class 'teflo.resources.actions.Action'> (Create OpenShift cluster)
2022-08-29 14:02:25,502 INFO successfully validated scenario Action Create OpenShift cluster against the schema!
2022-08-29 14:02:25,503 INFO ** BLASTER COMPLETE **
2022-08-29 14:02:25,504 INFO     -> TOTAL DURATION: 0h:0m:0s
2022-08-29 14:02:25,505 INFO ..................................................
2022-08-29 14:02:25,509 INFO ..................................................
2022-08-29 14:02:25,509 INFO 'execute' is validated from the scenario file: execute.yml
2022-08-29 14:02:25,510 INFO ..................................................
2022-08-29 14:02:25,510 INFO ..................................................
2022-08-29 14:02:25,511 INFO 'execute' is running from the scenario file: execute.yml
2022-08-29 14:02:25,511 INFO ..................................................
2022-08-29 14:02:25,514 INFO  * Task    : validate
2022-08-29 14:02:25,515 INFO ..................................................
2022-08-29 14:02:25,515 INFO Starting tasks on pipeline: validate
2022-08-29 14:02:25,516 INFO --> Blaster v0.5.0 <--
2022-08-29 14:02:25,517 INFO Task Execution: Sequential
2022-08-29 14:02:25,518 INFO Tasks:
2022-08-29 14:02:25,519 INFO 1. Task     : execute
                                Class    : <class 'teflo.tasks.validate.ValidateTask'>
                                Methods  : ['run']
2022-08-29 14:02:25,521 INFO 2. Task     : Execute test
                                Class    : <class 'teflo.tasks.validate.ValidateTask'>
                                Methods  : ['run']
2022-08-29 14:02:25,522 INFO ** BLASTER BEGIN **
2022-08-29 14:02:25,525 INFO Validating <class 'teflo.resources.scenario.Scenario'> (execute)
2022-08-29 14:02:25,585 INFO Validating <class 'teflo.resources.executes.Execute'> (Execute test)
2022-08-29 14:02:25,628 INFO successfully validated scenario Execute resource Execute test against the schema!
2022-08-29 14:02:25,629 INFO ** BLASTER COMPLETE **
2022-08-29 14:02:25,630 INFO     -> TOTAL DURATION: 0h:0m:0s
2022-08-29 14:02:25,631 INFO ..................................................
2022-08-29 14:02:25,633 INFO ..................................................
2022-08-29 14:02:25,634 INFO 'Layered product OpenShift unit test scenario' is validated from the scenario file: scenario_ocp_osp.yml
2022-08-29 14:02:25,634 INFO ..................................................
2022-08-29 14:02:25,634 INFO ..................................................
2022-08-29 14:02:25,635 INFO 'Layered product OpenShift unit test scenario' is running from the scenario file: scenario_ocp_osp.yml
2022-08-29 14:02:25,635 INFO ..................................................
2022-08-29 14:02:25,638 INFO  * Task    : validate
2022-08-29 14:02:25,638 INFO ..................................................
2022-08-29 14:02:25,639 INFO Starting tasks on pipeline: validate
2022-08-29 14:02:25,639 INFO --> Blaster v0.5.0 <--
2022-08-29 14:02:25,640 INFO Task Execution: Sequential
2022-08-29 14:02:25,640 INFO Tasks:
2022-08-29 14:02:25,641 INFO 1. Task     : Layered product OpenShift unit test scenario
                                Class    : <class 'teflo.tasks.validate.ValidateTask'>
                                Methods  : ['run']
2022-08-29 14:02:25,641 INFO ** BLASTER BEGIN **
2022-08-29 14:02:25,643 INFO Validating <class 'teflo.resources.scenario.Scenario'> (Layered product OpenShift unit test scenario)
2022-08-29 14:02:25,701 INFO ** BLASTER COMPLETE **
2022-08-29 14:02:25,701 INFO     -> TOTAL DURATION: 0h:0m:0s
2022-08-29 14:02:25,702 INFO ..................................................
2022-08-29 14:02:25,857 INFO 

2022-08-29 14:02:25,857 INFO                                SCENARIO RUN (END)                              
2022-08-29 14:02:25,858 INFO -------------------------------------------------------------------------------
2022-08-29 14:02:25,858 INFO  * Duration                       : 0h:0m:20s
2022-08-29 14:02:25,859 INFO  * Passed Tasks                   : ['validate']
2022-08-29 14:02:25,859 INFO  * Results Folder                 : ./.teflo/.results
2022-08-29 14:02:25,860 INFO  * Iterate Method                 : by_level
2022-08-29 14:02:25,860 INFO  * Scenario Definition            : resource_check
2022-08-29 14:02:25,861 INFO  * Scenario Definition            : provision_base
2022-08-29 14:02:25,861 INFO  * Scenario Definition            : orchestrate_base
2022-08-29 14:02:25,862 INFO  * Scenario Definition            : orchestrate
2022-08-29 14:02:25,862 INFO  * Scenario Definition            : orchestrate_install_openshift
2022-08-29 14:02:25,863 INFO  * Scenario Definition            : execute
2022-08-29 14:02:25,863 INFO  * Scenario Definition            : Layered product OpenShift unit test scenario
2022-08-29 14:02:25,864 INFO  * Final Scenario Definition      : ./.teflo/.results/results.yml
2022-08-29 14:02:25,864 INFO -------------------------------------------------------------------------------
2022-08-29 14:02:25,864 INFO TEFLO RUN (RESULT=PASSED)
```